### PR TITLE
Fix Robinhood connect: ephemeral OAuth loopback, bounded + cancellable consent, error_code telemetry

### DIFF
--- a/app/src/main/services/analytics/analytics.test.ts
+++ b/app/src/main/services/analytics/analytics.test.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   assetTypeOf,
+  errorCodeOf,
   errorNameOf,
   orderKindOf,
   orderTypeOf,
@@ -177,6 +178,38 @@ describe("AnalyticsService", () => {
       subsystem: "host",
       source: "unhandled_rejection",
     });
+    // No code on the error → the prop is absent, not null/empty.
+    expect(fake.events[0].properties).not.toHaveProperty("error_code");
+  });
+
+  test("trackError carries err.code for a Node system error whose stack has no bundle frame", () => {
+    const fake = new FakeClient();
+    const svc = makeService(new SettingsService(memDb()), fake);
+    // The exact shape of a `listen EADDRINUSE` rejection: plain Error, code set, and a
+    // stack made only of node:internal frames — so `frames` is empty and, before
+    // error_code, PostHog received nothing that said what went wrong.
+    const err = Object.assign(
+      new Error("listen EADDRINUSE: address already in use 127.0.0.1:8771"),
+      {
+        code: "EADDRINUSE",
+      },
+    );
+    err.stack =
+      "Error: listen EADDRINUSE: address already in use 127.0.0.1:8771\n" +
+      "    at Server.setupListenHandle [as _listen2] (node:net:1940:16)\n" +
+      "    at listenInCluster (node:net:1997:12)\n" +
+      "    at node:net:2206:7\n" +
+      "    at process.processTicksAndRejections (node:internal/process/task_queues:89:21)";
+    svc.trackError("host", err, "unhandled_rejection");
+    expect(fake.events).toHaveLength(1);
+    expect(fake.events[0].properties).toMatchObject({
+      subsystem: "host",
+      error_name: "Error",
+      error_code: "EADDRINUSE",
+      source: "unhandled_rejection",
+    });
+    expect(fake.events[0].properties).not.toHaveProperty("frames");
+    expect(JSON.stringify(fake.events[0].properties)).not.toContain("127.0.0.1");
   });
 });
 
@@ -214,6 +247,38 @@ describe("analytics allowlist + normalizers", () => {
       error_name: "has spaces and /paths",
     });
     expect(bad.success).toBe(false);
+  });
+
+  test("errorCodeOf takes err.code only when it is already a bare identifier", () => {
+    // Node system errors: class is plain `Error`, the code is the whole story.
+    const sys = Object.assign(new Error("listen EADDRINUSE: address already in use"), {
+      code: "EADDRINUSE",
+      errno: -48,
+      syscall: "listen",
+    });
+    expect(errorCodeOf(sys)).toBe("EADDRINUSE");
+    expect(errorCodeOf(Object.assign(new Error("x"), { code: "ERR_SOCKET_CLOSED" }))).toBe(
+      "ERR_SOCKET_CLOSED",
+    );
+    // No code → undefined (never invents one).
+    expect(errorCodeOf(new Error("plain"))).toBeUndefined();
+    expect(errorCodeOf(new TypeError("fetch failed"))).toBeUndefined();
+    expect(errorCodeOf(null)).toBeUndefined();
+    expect(errorCodeOf("EADDRINUSE")).toBeUndefined();
+    // A code that isn't a bare identifier is dropped whole, not truncated/coerced.
+    expect(
+      errorCodeOf(Object.assign(new Error("x"), { code: "bad code /Users/a" })),
+    ).toBeUndefined();
+    expect(errorCodeOf(Object.assign(new Error("x"), { code: "x".repeat(49) }))).toBeUndefined();
+    // Numeric codes (DOMException.code) are ignored.
+    expect(errorCodeOf(Object.assign(new Error("x"), { code: 18 }))).toBeUndefined();
+    // broker_connect_failed carries the same field.
+    expect(
+      TELEMETRY_EVENTS.broker_connect_failed.safeParse({
+        error_name: "OAuthFlowError",
+        error_code: "OAUTH_TIMEOUT",
+      }).success,
+    ).toBe(true);
   });
 
   test("app_error source accepts the enum and rejects free text", () => {

--- a/app/src/main/services/analytics/index.ts
+++ b/app/src/main/services/analytics/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import {
   type ErrorSource,
   type ErrorSubsystem,
+  errorCodeOf,
   errorNameOf,
   sanitizeStack,
   TELEMETRY_EVENTS,
@@ -149,16 +150,22 @@ export class AnalyticsService {
   }
 
   /**
-   * Capture a sanitized `app_error`: the error class name + bundle-only stack
-   * fingerprint, plus how it surfaced (`source`). Never the message, a stack line's
-   * path, or any free text. `source` defaults to `caught` — the value for an explicit
-   * try/catch; the global process handlers pass `uncaught_exception` / `unhandled_rejection`.
+   * Capture a sanitized `app_error`: the error class name, its machine code when it
+   * has one (`err.code` — e.g. `EADDRINUSE`), and a bundle-only stack fingerprint,
+   * plus how it surfaced (`source`). Never the message, a stack line's path, or any
+   * free text. `source` defaults to `caught` — the value for an explicit try/catch;
+   * the global process handlers pass `uncaught_exception` / `unhandled_rejection`.
+   * The code matters most for async Node system errors: their stack is entirely
+   * `node:internal` frames (so `frames` is empty) and their class is plain `Error`,
+   * leaving `error_code` as the only thing that says what actually went wrong.
    */
   trackError(subsystem: ErrorSubsystem, err: unknown, source: ErrorSource = "caught"): void {
     const frames = sanitizeStack(err);
+    const code = errorCodeOf(err);
     this.track("app_error", {
       subsystem,
       error_name: errorNameOf(err),
+      ...(code ? { error_code: code } : {}),
       source,
       ...(frames.length ? { frames } : {}),
     });

--- a/app/src/main/services/broker/adapter.ts
+++ b/app/src/main/services/broker/adapter.ts
@@ -7,6 +7,18 @@ export interface McpServerConfig {
 }
 
 /**
+ * Thrown to a pending interactive connect when a newer one takes over (the user
+ * clicked Connect again, most likely after abandoning the browser consent). Not a
+ * broker failure: the service neither reports it nor touches the connection status.
+ */
+export class ConnectSuperseded extends Error {
+  constructor() {
+    super("connect superseded by a newer connect");
+    this.name = "ConnectSuperseded";
+  }
+}
+
+/**
  * A trading execution + read backend. v1 implements Robinhood only, but the read
  * panel, poller, and faucet all speak this interface so a second broker (e.g.
  * Alpaca) slots in later.
@@ -21,6 +33,17 @@ export interface BrokerAdapter {
    * stays disconnected — never pops a browser unprompted.
    */
   connect(opts?: { interactive?: boolean }): Promise<void>;
+  /**
+   * Abandon an interactive connect waiting on the user (browser consent): its pending
+   * `connect()` rejects with `ConnectSuperseded`. No-op when nothing is pending.
+   */
+  cancelConnect?(): void;
+  /**
+   * Forget the session: abandon any pending consent, drop stored tokens + client
+   * registration, close the live connection. The next `connect({interactive})` is a
+   * fresh consent. Backs the user's Reset/Disconnect action.
+   */
+  reset(): void;
   isConnected(): boolean;
   listAccounts(): Promise<Account[]>;
   getPortfolio(accountNumber: string): Promise<Portfolio>;

--- a/app/src/main/services/broker/connect.test.ts
+++ b/app/src/main/services/broker/connect.test.ts
@@ -1,0 +1,253 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Account } from "@shared/broker";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import type { Db } from "../../db/client";
+import * as schema from "../../db/schema";
+import { analytics, type CaptureClient } from "../analytics";
+import { SettingsService } from "../settings";
+import { type BrokerAdapter, ConnectSuperseded } from "./adapter";
+import { BrokerService } from "./index";
+
+function memDb(): Db {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+  sqlite.exec(
+    "CREATE TABLE broker_cache (key TEXT PRIMARY KEY, payload TEXT NOT NULL, fetched_at INTEGER NOT NULL)",
+  );
+  return drizzle(sqlite, { schema }) as unknown as Db;
+}
+
+interface Deferred {
+  resolve: () => void;
+  reject: (err: unknown) => void;
+  opts: { interactive?: boolean };
+}
+
+/**
+ * The slice of BrokerAdapter `connect()` touches, with `connect` a hand-controlled
+ * promise per call so tests can hold one in flight and land a second on top of it.
+ * `cancelConnect` does what the real one does to a pending interactive flow: rejects
+ * it with ConnectSuperseded. (No account → the poller never starts.)
+ */
+class FakeAdapter {
+  calls: Deferred[] = [];
+  cancels = 0;
+  connected = false;
+
+  connect(opts: { interactive?: boolean } = {}): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.calls.push({ resolve, reject, opts });
+    });
+  }
+  cancelConnect(): void {
+    this.cancels++;
+    const pending = this.calls.find((c) => c.opts.interactive && !("done" in c));
+    if (pending) {
+      Object.assign(pending, { done: true });
+      pending.reject(new ConnectSuperseded());
+    }
+  }
+  /** Land call #i as connected. */
+  succeed(i: number) {
+    this.connected = true;
+    Object.assign(this.calls[i], { done: true });
+    this.calls[i].resolve();
+  }
+  fail(i: number, err: unknown) {
+    Object.assign(this.calls[i], { done: true });
+    this.calls[i].reject(err);
+  }
+  isConnected() {
+    return this.connected;
+  }
+  resets = 0;
+  reset() {
+    this.resets++;
+    this.cancelConnect();
+    this.connected = false;
+  }
+  async listAccounts(): Promise<Account[]> {
+    return [];
+  }
+}
+
+interface Captured {
+  event: string;
+  properties?: Record<string, unknown>;
+}
+class FakeClient implements CaptureClient {
+  events: Captured[] = [];
+  capture(msg: Captured): void {
+    this.events.push(msg);
+  }
+  async shutdown(): Promise<void> {}
+}
+
+// The service reports through the module singleton, which wires itself once
+// (`start` is idempotent), so capture into one fake client for the whole file and
+// clear it per test.
+const client = new FakeClient();
+analytics.start({ settings: new SettingsService(memDb()), client });
+beforeEach(() => {
+  client.events.length = 0;
+});
+
+const services: BrokerService[] = [];
+afterEach(() => {
+  while (services.length) services.pop()?.stopPolling();
+});
+
+function setup() {
+  const db = memDb();
+  const settings = new SettingsService(db);
+  const adapter = new FakeAdapter();
+  const svc = new BrokerService(db, adapter as unknown as BrokerAdapter, settings, {
+    agentForOrder: () => null,
+  });
+  services.push(svc);
+  return { svc, adapter, client };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("BrokerService.connect — one connect at a time", () => {
+  test("a silent connect joins the one in flight instead of starting another", async () => {
+    const { svc, adapter } = setup();
+    const first = svc.connect();
+    await tick();
+    const second = svc.connect();
+    await tick();
+    expect(adapter.calls).toHaveLength(1);
+    expect(adapter.cancels).toBe(0);
+    adapter.succeed(0);
+    await Promise.all([first, second]);
+    expect(svc.getStatus()).toBe("connected");
+  });
+
+  test("an interactive connect supersedes a pending interactive one", async () => {
+    const { svc, adapter, client } = setup();
+    const first = svc.connect({ interactive: true });
+    await tick();
+    expect(svc.getStatus()).toBe("connecting");
+    // The user clicks Connect again while the first is waiting on the browser.
+    const second = svc.connect({ interactive: true });
+    await tick();
+    expect(adapter.cancels).toBe(1);
+    // The abandoned call resolves quietly — no error to the caller, no failure event,
+    // and the status is left to the attempt that took over.
+    await first;
+    expect(svc.getStatus()).toBe("connecting");
+    expect(client.events.map((e) => e.event)).not.toContain("broker_connect_failed");
+    // The second attempt is now the one in flight, and it can complete.
+    expect(adapter.calls).toHaveLength(2);
+    expect(adapter.calls[1].opts.interactive).toBe(true);
+    adapter.succeed(1);
+    await second;
+    expect(svc.getStatus()).toBe("connected");
+    expect(client.events.map((e) => e.event)).toContain("broker_connected");
+  });
+
+  test("an interactive connect waits for a pending silent one, then proceeds", async () => {
+    const { svc, adapter } = setup();
+    const silent = svc.connect();
+    await tick();
+    const click = svc.connect({ interactive: true });
+    await tick();
+    // Nothing to cancel on the silent path (no browser waiting); it just runs to its end.
+    expect(adapter.calls).toHaveLength(1);
+    adapter.fail(0, new Error("silent path: no session"));
+    await silent.catch(() => {});
+    await tick();
+    // …and only then does the click get its own attempt.
+    expect(adapter.calls).toHaveLength(2);
+    adapter.succeed(1);
+    await click;
+    expect(svc.getStatus()).toBe("connected");
+  });
+
+  test("once connected, further connects are no-ops", async () => {
+    const { svc, adapter } = setup();
+    const c = svc.connect();
+    await tick();
+    adapter.succeed(0);
+    await c;
+    await svc.connect({ interactive: true });
+    expect(adapter.calls).toHaveLength(1);
+  });
+});
+
+describe("BrokerService.disconnect — the user's Reset/Cancel", () => {
+  test("while a consent is pending: abandons it, forgets the session, status → disconnected", async () => {
+    const { svc, adapter, client } = setup();
+    // The user clicked Connect and closed the browser tab: the flow is waiting on the
+    // loopback with nothing to unstick it, the panel spinning on "connecting".
+    const click = svc.connect({ interactive: true });
+    await tick();
+    expect(svc.getStatus()).toBe("connecting");
+    await svc.disconnect();
+    // The abandoned click resolves quietly (superseded), not as a failure…
+    await click;
+    expect(client.events.map((e) => e.event)).not.toContain("broker_connect_failed");
+    // …the session is forgotten, and the Connect CTA is back.
+    expect(adapter.resets).toBe(1);
+    expect(svc.getStatus()).toBe("disconnected");
+    // A fresh Connect starts a new attempt rather than joining anything stale.
+    const again = svc.connect({ interactive: true });
+    await tick();
+    expect(adapter.calls).toHaveLength(2);
+    adapter.succeed(1);
+    await again;
+    expect(svc.getStatus()).toBe("connected");
+  });
+
+  test("while connected: forgets the session and stops polling", async () => {
+    const { svc, adapter } = setup();
+    const c = svc.connect();
+    await tick();
+    adapter.succeed(0);
+    await c;
+    expect(svc.getStatus()).toBe("connected");
+    await svc.disconnect();
+    expect(adapter.resets).toBe(1);
+    expect(svc.getStatus()).toBe("disconnected");
+    expect(svc.getAccount()).toBeNull();
+  });
+
+  test("when idle: harmless", async () => {
+    const { svc, adapter } = setup();
+    await svc.disconnect();
+    expect(adapter.resets).toBe(1);
+    expect(svc.getStatus()).toBe("disconnected");
+  });
+});
+
+describe("BrokerService.connect — failure telemetry", () => {
+  test("broker_connect_failed carries the error's machine code when it has one", async () => {
+    const { svc, adapter, client } = setup();
+    const c = svc.connect({ interactive: true });
+    await tick();
+    adapter.fail(
+      0,
+      Object.assign(new Error("listen EADDRINUSE: address already in use 127.0.0.1:8771"), {
+        code: "EADDRINUSE",
+      }),
+    );
+    await expect(c).rejects.toBeDefined();
+    expect(svc.getStatus()).toBe("error");
+    const failed = client.events.find((e) => e.event === "broker_connect_failed");
+    expect(failed?.properties).toMatchObject({ error_name: "Error", error_code: "EADDRINUSE" });
+    expect(JSON.stringify(failed?.properties)).not.toContain("127.0.0.1");
+  });
+
+  test("…and omits it when there is none", async () => {
+    const { svc, adapter, client } = setup();
+    const c = svc.connect({ interactive: true });
+    await tick();
+    adapter.fail(0, new TypeError("fetch failed"));
+    await expect(c).rejects.toBeDefined();
+    const failed = client.events.find((e) => e.event === "broker_connect_failed");
+    expect(failed?.properties).toMatchObject({ error_name: "TypeError" });
+    expect(failed?.properties).not.toHaveProperty("error_code");
+  });
+});

--- a/app/src/main/services/broker/index.ts
+++ b/app/src/main/services/broker/index.ts
@@ -1,4 +1,4 @@
-import { errorNameOf } from "@shared/analytics";
+import { errorCodeOf, errorNameOf } from "@shared/analytics";
 import type {
   Account,
   BrokerConnectionStatus,
@@ -13,7 +13,7 @@ import { brokerCache } from "../../db/schema";
 import { analytics } from "../analytics";
 import { bus } from "../event-bus";
 import type { SettingsService } from "../settings";
-import type { BrokerAdapter } from "./adapter";
+import { type BrokerAdapter, ConnectSuperseded } from "./adapter";
 import { orderNotification, terminalTransition } from "./order-notify";
 
 /**
@@ -65,6 +65,14 @@ export class BrokerService {
   private ledger = new Map<string, OrderStatus>();
   /** When the last full-history sweep ran; 0 forces a sweep on the next poll. */
   private lastFullSweepAt = 0;
+  /**
+   * The connect in flight, if any — two never run at once (the adapter's consent flow
+   * relies on that). A silent connect joins it; an interactive one (a Connect click)
+   * supersedes it, since a pending flow is most likely a browser consent the user
+   * abandoned. Best-effort: if the click lands before the pending flow has bound its
+   * loopback (a tick or two), the cancel is a no-op and the click just waits for it.
+   */
+  private inflight: Promise<void> | null = null;
 
   constructor(
     private db: Db,
@@ -111,7 +119,26 @@ export class BrokerService {
    * omits it and just stays disconnected on a dead grant (§6.6).
    */
   async connect(opts: { interactive?: boolean } = {}): Promise<void> {
+    // Join or supersede whatever is in flight, then re-check — another caller may
+    // have started a new attempt while we waited.
+    while (this.inflight) {
+      if (this.status === "connected") return;
+      if (!opts.interactive) return this.inflight;
+      const current = this.inflight;
+      this.adapter.cancelConnect?.();
+      await current.catch(() => {});
+    }
     if (this.status === "connected") return;
+    const promise = this.runConnect(opts);
+    this.inflight = promise;
+    try {
+      await promise;
+    } finally {
+      if (this.inflight === promise) this.inflight = null;
+    }
+  }
+
+  private async runConnect(opts: { interactive?: boolean }): Promise<void> {
     this.setStatus("connecting");
     try {
       await this.adapter.connect(opts);
@@ -129,10 +156,36 @@ export class BrokerService {
       await this.pollOnce();
       this.startPolling();
     } catch (err) {
+      // A newer connect took this one over (the user clicked Connect again): not a
+      // failure — the newer attempt owns the status now, so leave it and report nothing.
+      // The abandoned call resolves quietly rather than surfacing a spurious error.
+      if (err instanceof ConnectSuperseded) return;
       this.setStatus("error");
-      analytics.track("broker_connect_failed", { error_name: errorNameOf(err) });
+      const code = errorCodeOf(err);
+      analytics.track("broker_connect_failed", {
+        error_name: errorNameOf(err),
+        ...(code ? { error_code: code } : {}),
+      });
       throw err;
     }
+  }
+
+  /**
+   * The explicit Reset/Disconnect action: abandon a consent still waiting on the
+   * browser (the user closed the tab — nothing else can unstick "connecting"), forget
+   * the stored session, stop polling. Status → `disconnected`, so the Connect CTA comes
+   * back and the next Connect is a fresh consent. Also how a user switches accounts.
+   */
+  async disconnect(): Promise<void> {
+    this.adapter.cancelConnect?.();
+    // Let the in-flight connect unwind (a superseded one resolves quietly and leaves the
+    // status alone — it's ours to set below).
+    await this.inflight?.catch(() => {});
+    this.stopPolling();
+    this.adapter.reset();
+    this.account = null;
+    this.ledger.clear();
+    this.setStatus("disconnected");
   }
 
   /** True if we already have tokens and can connect without a browser. */

--- a/app/src/main/services/broker/robinhood/client.test.ts
+++ b/app/src/main/services/broker/robinhood/client.test.ts
@@ -1,7 +1,21 @@
-import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type Server } from "node:http";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { InvalidGrantError, ServerError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
-import { isReauthRequired } from "./client";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import type { Db } from "../../../db/client";
+import * as schema from "../../../db/schema";
+import { ConnectSuperseded } from "../adapter";
+import {
+  isReauthRequired,
+  type Loopback,
+  OAuthFlowError,
+  oauthErrorCode,
+  openLoopback,
+  RobinhoodAdapter,
+} from "./client";
+import { ConsentRequired } from "./oauth";
 
 describe("isReauthRequired", () => {
   test("401 (UnauthorizedError) → re-auth", () => {
@@ -23,5 +37,348 @@ describe("isReauthRequired", () => {
     expect(isReauthRequired("invalid_grant")).toBe(false);
     expect(isReauthRequired(undefined)).toBe(false);
     expect(isReauthRequired(null)).toBe(false);
+  });
+});
+
+describe("oauthErrorCode", () => {
+  test("maps an RFC 6749 callback error to OAUTH_*; anything else is OAUTH_UNKNOWN", () => {
+    expect(oauthErrorCode("access_denied")).toBe("OAUTH_ACCESS_DENIED");
+    expect(oauthErrorCode("server_error")).toBe("OAUTH_SERVER_ERROR");
+    expect(oauthErrorCode(null)).toBe("OAUTH_UNKNOWN");
+    expect(oauthErrorCode("")).toBe("OAUTH_UNKNOWN");
+    // A closed whitelist: free text can't ride along, even as letters.
+    expect(oauthErrorCode("bad thing /Users/alice")).toBe("OAUTH_UNKNOWN");
+    expect(oauthErrorCode("ACCESS_DENIED")).toBe("OAUTH_UNKNOWN");
+  });
+});
+
+// ---- the loopback listener ----
+
+const open: Loopback[] = [];
+const servers: Server[] = [];
+afterEach(() => {
+  while (open.length) open.pop()?.close();
+  while (servers.length) servers.pop()?.close();
+});
+
+async function loopback(opts: { timeoutMs?: number; port?: number } = {}): Promise<Loopback> {
+  const lb = await openLoopback(opts);
+  open.push(lb);
+  return lb;
+}
+
+/** Hit the loopback's callback like the browser redirect would. */
+async function callback(lb: Loopback, query: string): Promise<Response> {
+  return fetch(`${lb.redirectUrl}?${query}`);
+}
+
+/** Watch for unhandled rejections during `fn` — the exact bug that fired `app_error`. */
+async function noUnhandledRejections(fn: () => Promise<void>): Promise<void> {
+  const seen: unknown[] = [];
+  const onUnhandled = (reason: unknown) => seen.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    await fn();
+    // Give the microtask queue + a macrotask turn a chance to surface anything.
+    await new Promise((r) => setTimeout(r, 20));
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+  expect(seen).toEqual([]);
+}
+
+describe("openLoopback", () => {
+  test("binds an ephemeral 127.0.0.1 port; two loopbacks never collide", async () => {
+    const a = await loopback();
+    const b = await loopback();
+    const portOf = (lb: Loopback) => Number(new URL(lb.redirectUrl).port);
+    expect(new URL(a.redirectUrl).hostname).toBe("127.0.0.1");
+    expect(new URL(a.redirectUrl).pathname).toBe("/callback");
+    expect(portOf(a)).toBeGreaterThan(0);
+    expect(portOf(b)).toBeGreaterThan(0);
+    expect(portOf(a)).not.toBe(portOf(b));
+    // Nothing is pinned to the old fixed port anymore.
+    expect(portOf(a)).not.toBe(8771);
+  });
+
+  test("resolves the code from the callback and answers the browser with a page", async () => {
+    const lb = await loopback();
+    const res = await callback(lb, "code=abc123&state=opentrade");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("OpenTrade connected");
+    expect(await lb.code).toBe("abc123");
+  });
+
+  test("an OAuth error on the callback rejects with a bounded OAUTH_* code", async () => {
+    const lb = await loopback();
+    const res = await callback(lb, "error=access_denied&error_description=The+user+declined");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Authorization failed");
+    const err = await lb.code.catch((e) => e);
+    expect(err).toBeInstanceOf(OAuthFlowError);
+    expect(err.name).toBe("OAuthFlowError");
+    expect(err.code).toBe("OAUTH_ACCESS_DENIED");
+    // The description (free text) is never carried on the error.
+    expect(String(err.message)).not.toContain("declined");
+  });
+
+  test("other paths 404 and don't settle the flow", async () => {
+    const lb = await loopback();
+    const res = await fetch(new URL("/favicon.ico", lb.redirectUrl));
+    expect(res.status).toBe(404);
+    let settled = false;
+    lb.code.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(settled).toBe(false);
+  });
+
+  test("times out with OAUTH_TIMEOUT and releases the port", async () => {
+    const lb = await loopback({ timeoutMs: 30 });
+    const err = await lb.code.catch((e) => e);
+    expect(err).toBeInstanceOf(OAuthFlowError);
+    expect(err.code).toBe("OAUTH_TIMEOUT");
+    // The port is free again: nobody answers on it.
+    await expect(callback(lb, "code=late")).rejects.toBeDefined();
+  });
+
+  test("close() on a pending flow rejects with ConnectSuperseded and releases the port", async () => {
+    const lb = await loopback();
+    lb.close();
+    const err = await lb.code.catch((e) => e);
+    expect(err).toBeInstanceOf(ConnectSuperseded);
+    await expect(callback(lb, "code=late")).rejects.toBeDefined();
+  });
+
+  test("a rejection nobody is awaiting yet is NOT an unhandledRejection", async () => {
+    // The consumer awaits `code` only after a network round-trip; before this fix, a
+    // listener error rejecting in that window surfaced as `unhandledRejection` → the
+    // `app_error {subsystem: host, error_name: Error, source: unhandled_rejection}` seen
+    // in telemetry, with no useful detail.
+    await noUnhandledRejections(async () => {
+      const lb = await loopback();
+      lb.close();
+      await new Promise((r) => setTimeout(r, 10)); // still un-awaited here
+      const err = await lb.code.catch((e) => e); // the real await still sees it
+      expect(err).toBeInstanceOf(ConnectSuperseded);
+    });
+  });
+
+  test("a bind failure rejects openLoopback itself (before any browser opens)", async () => {
+    // Occupy a port, then ask the loopback for that exact port.
+    const blocker = createServer();
+    servers.push(blocker);
+    await new Promise<void>((r) => blocker.listen(0, "127.0.0.1", () => r()));
+    const port = (blocker.address() as { port: number }).port;
+    await noUnhandledRejections(async () => {
+      const err = await openLoopback({ port }).catch((e) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.code).toBe("EADDRINUSE");
+    });
+  });
+});
+
+// ---- the adapter's connect() branching + the interactive flow ----
+
+function memDb(): Db {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+  return drizzle(sqlite, { schema }) as unknown as Db;
+}
+
+/**
+ * The adapter with the two network calls stubbed: `doConnect` (the MCP client
+ * connect that drives the SDK's auth) and `exchangeCode` (the token exchange). What
+ * the stubs do is scripted per test; everything else — the loopback, the provider,
+ * the branching in `connect()` / `interactiveConnect()` — is the real code.
+ */
+class TestAdapter extends RobinhoodAdapter {
+  connectScript: (call: number) => Promise<void> = async () => {};
+  connectCalls = 0;
+  exchanged: string[] = [];
+  opened: string[] = [];
+
+  constructor(db: Db) {
+    const opened: string[] = [];
+    super({ db, openBrowser: (url) => opened.push(url) });
+    this.opened = opened;
+  }
+
+  get prov() {
+    return this.provider;
+  }
+
+  protected override async doConnect(): Promise<void> {
+    this.connectCalls++;
+    await this.connectScript(this.connectCalls);
+  }
+
+  protected override async exchangeCode(code: string): Promise<void> {
+    this.exchanged.push(code);
+  }
+
+  /** The SDK's move when it wants consent: ask the provider to open the browser. */
+  wantConsent() {
+    this.prov.redirectToAuthorization(new URL("https://robinhood.com/oauth?x=1"));
+    throw new UnauthorizedError("redirect");
+  }
+}
+
+const TOKENS = { access_token: "a", token_type: "bearer", refresh_token: "r" };
+
+async function until(pred: () => boolean, ms = 2000): Promise<void> {
+  const t0 = Date.now();
+  while (!pred()) {
+    if (Date.now() - t0 > ms) throw new Error("timed out waiting");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+const adapters: TestAdapter[] = [];
+afterEach(() => {
+  while (adapters.length) adapters.pop()?.cancelConnect();
+});
+function adapter(): TestAdapter {
+  const a = new TestAdapter(memDb());
+  adapters.push(a);
+  return a;
+}
+
+describe("RobinhoodAdapter.connect — silent vs interactive", () => {
+  test("silent + tokens + ConsentRequired: keeps the tokens, no browser, stays disconnected", async () => {
+    const a = adapter();
+    a.prov.saveTokens(TOKENS);
+    a.connectScript = async () => a.wantConsent();
+    await a.connect();
+    expect(a.isConnected()).toBe(false);
+    expect(a.hasTokens()).toBe(true); // the refresh failed transiently — don't nuke it
+    expect(a.opened).toEqual([]); // never a browser unprompted
+  });
+
+  test("silent + tokens + InvalidGrantError (dead grant): drops the tokens, no browser", async () => {
+    const a = adapter();
+    a.prov.saveTokens(TOKENS);
+    a.connectScript = async () => {
+      throw new InvalidGrantError("invalid_grant");
+    };
+    await a.connect();
+    expect(a.hasTokens()).toBe(false);
+    expect(a.opened).toEqual([]);
+  });
+
+  test("silent + tokens + transient ServerError: propagates, tokens kept", async () => {
+    const a = adapter();
+    a.prov.saveTokens(TOKENS);
+    a.connectScript = async () => {
+      throw new ServerError("5xx");
+    };
+    await expect(a.connect()).rejects.toBeInstanceOf(ServerError);
+    expect(a.hasTokens()).toBe(true);
+    expect(a.opened).toEqual([]);
+  });
+
+  test("silent + no tokens: nothing happens", async () => {
+    const a = adapter();
+    await a.connect();
+    expect(a.connectCalls).toBe(0);
+    expect(a.opened).toEqual([]);
+  });
+
+  test("interactive + tokens + ConsentRequired: fresh consent replaces the session", async () => {
+    const a = adapter();
+    a.prov.saveTokens(TOKENS);
+    a.connectScript = async (call) => {
+      if (call === 1) a.wantConsent(); // the token connect: SDK wants a browser
+      if (call === 2) a.wantConsent(); // interactiveConnect's kickoff: now allowed
+      // call 3 (after the exchange): connected
+    };
+    const done = a.connect({ interactive: true });
+    await until(() => a.opened.length === 1);
+    expect(a.hasTokens()).toBe(false); // the maybe-good session was dropped for a fresh one
+    // Complete the consent on the loopback the flow bound.
+    await fetch(`${a.prov.redirectUrl}?code=fresh`);
+    await done;
+    expect(a.exchanged).toEqual(["fresh"]);
+    expect(a.connectCalls).toBe(3);
+  });
+});
+
+describe("RobinhoodAdapter interactive consent flow", () => {
+  test("registers under the loopback's redirect URL, opens one browser, exchanges the code", async () => {
+    const a = adapter();
+    // A stale registration from an earlier, abandoned attempt (made under a different
+    // port). It must not be reused — Robinhood would reject the redirect_uri.
+    a.prov.saveClientInformation({ client_id: "stale" });
+    a.connectScript = async (call) => {
+      if (call === 1) {
+        // What the SDK sees at this point: no client (cleared → will re-register), a
+        // redirect URL pointing at the loopback that was just bound.
+        expect(a.prov.clientInformation()).toBeUndefined();
+        expect(a.prov.redirectUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+        expect(a.prov.clientMetadata.redirect_uris).toEqual([a.prov.redirectUrl]);
+        a.wantConsent();
+      }
+    };
+    const done = a.connect({ interactive: true });
+    await until(() => a.opened.length === 1);
+    expect(a.opened[0]).toContain("robinhood.com/oauth");
+    await fetch(`${a.prov.redirectUrl}?code=c1`);
+    await done;
+    expect(a.exchanged).toEqual(["c1"]);
+    expect(a.connectCalls).toBe(2);
+    // The browser gate closed again once the flow ended.
+    expect(() => a.prov.redirectToAuthorization(new URL("https://x"))).toThrow(ConsentRequired);
+  });
+
+  test("the user declining rejects the connect with OAUTH_ACCESS_DENIED", async () => {
+    const a = adapter();
+    a.connectScript = async () => a.wantConsent();
+    // Capture the outcome up front: the rejection lands on a later I/O turn than the
+    // callback fetch resolves on, so a late `.catch` would read as unhandled.
+    const outcome = a.connect({ interactive: true }).then(
+      () => null,
+      (e) => e,
+    );
+    await until(() => a.opened.length === 1);
+    await fetch(`${a.prov.redirectUrl}?error=access_denied`);
+    const err = await outcome;
+    expect(err).toBeInstanceOf(OAuthFlowError);
+    expect(err.code).toBe("OAUTH_ACCESS_DENIED");
+    expect(a.exchanged).toEqual([]);
+  });
+
+  test("a second interactive connect supersedes a pending one — no overlap, no unhandled rejection", async () => {
+    await noUnhandledRejections(async () => {
+      const a = adapter();
+      a.connectScript = async (call) => {
+        if (call === 1 || call === 2) a.wantConsent();
+      };
+      const first = a.connect({ interactive: true }).then(
+        () => null,
+        (e) => e,
+      );
+      await until(() => a.opened.length === 1);
+      const firstUrl = a.prov.redirectUrl;
+
+      // The user clicks Connect again (from another surface / a remounted screen).
+      const second = a.connect({ interactive: true });
+      // The first attempt is abandoned in favor of the second — quietly, with a marker
+      // the service recognizes, not a generic failure.
+      expect(await first).toBeInstanceOf(ConnectSuperseded);
+      // Its loopback is gone…
+      await expect(fetch(`${firstUrl}?code=late`)).rejects.toBeDefined();
+      // …and the second bound its own, on a different port, and opened its own browser.
+      await until(() => a.opened.length === 2);
+      expect(a.prov.redirectUrl).not.toBe(firstUrl);
+      await fetch(`${a.prov.redirectUrl}?code=c2`);
+      await second;
+      expect(a.exchanged).toEqual(["c2"]);
+    });
   });
 });

--- a/app/src/main/services/broker/robinhood/client.ts
+++ b/app/src/main/services/broker/robinhood/client.ts
@@ -1,11 +1,12 @@
-import { createServer, type Server } from "node:http";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { InvalidGrantError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import type { Account, OrderStatus, Portfolio, Position, Quote } from "@shared/broker";
 import type { Db } from "../../../db/client";
-import type { BrokerAdapter, McpServerConfig } from "../adapter";
+import { type BrokerAdapter, ConnectSuperseded, type McpServerConfig } from "../adapter";
 import {
   mapAccounts,
   mapOrderStatuses,
@@ -17,11 +18,131 @@ import {
   RH_TOOLS,
   unwrap,
 } from "./mapping";
-import { BrokerOAuthProvider } from "./oauth";
+import { BrokerOAuthProvider, ConsentRequired } from "./oauth";
 
 const SERVER_URL = "https://agent.robinhood.com/mcp/trading";
-const CALLBACK_PORT = 8771;
-const REDIRECT_URL = `http://127.0.0.1:${CALLBACK_PORT}/callback`;
+const LOOPBACK_HOST = "127.0.0.1";
+/** Generous: a Robinhood login can involve 2FA. Waiting is cheap (ephemeral, cancellable). */
+const CONSENT_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * A consent flow that ended without an authorization code. `code` says why, as a
+ * bounded token telemetry can carry (`error_code`): `OAUTH_TIMEOUT` when nobody came
+ * back to the loopback, or `OAUTH_<ERROR>` for the RFC 6749 error the authorization
+ * server sent to the callback (`OAUTH_ACCESS_DENIED` = the user declined).
+ */
+export class OAuthFlowError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "OAuthFlowError";
+  }
+}
+
+/** The closed set of `error` values an authorization server may send (RFC 6749 §4.1.2.1). */
+const OAUTH_ERRORS = new Set([
+  "access_denied",
+  "invalid_request",
+  "unauthorized_client",
+  "unsupported_response_type",
+  "invalid_scope",
+  "server_error",
+  "temporarily_unavailable",
+]);
+
+/** `access_denied` → `OAUTH_ACCESS_DENIED`; anything off the RFC list → `OAUTH_UNKNOWN`. */
+export function oauthErrorCode(error: string | null | undefined): string {
+  return error && OAUTH_ERRORS.has(error) ? `OAUTH_${error.toUpperCase()}` : "OAUTH_UNKNOWN";
+}
+
+/** A bound loopback redirect listener for one consent flow. */
+export interface Loopback {
+  /** `http://127.0.0.1:<port>/callback` — the port is ephemeral, chosen at bind. */
+  readonly redirectUrl: string;
+  /**
+   * The authorization code, once the browser is redirected back. Rejects with
+   * `OAuthFlowError` (declined / timed out), `ConnectSuperseded` (cancelled), or the
+   * listener's own error. Safe to leave un-awaited for a while: a rejection is
+   * pre-handled here so it can never surface as an `unhandledRejection`.
+   */
+  readonly code: Promise<string>;
+  /** Release the port; if `code` is still pending, reject it with `reason`. Idempotent. */
+  close(reason?: Error): void;
+}
+
+/**
+ * Bind the loopback redirect listener for a consent flow on an **ephemeral** port
+ * (RFC 8252 §7.3). Why ephemeral, awaited, bounded: a fixed port (8771) failed with
+ * `EADDRINUSE` whenever anything else held it — another app, a second OpenTrade host,
+ * or an earlier consent of the *same* host still waiting on a browser tab the user had
+ * closed (the wait had no timeout, so that pinned the port for the life of the host and
+ * failed every later Connect). And its listener error rejected a promise nobody was
+ * awaiting yet, surfacing as an `unhandledRejection` while the browser opened anyway.
+ * Now: the port is per flow, this resolves only once actually listening (a bind failure
+ * is an ordinary rejection *before* any browser opens), and the wait times out.
+ */
+export async function openLoopback(
+  opts: { timeoutMs?: number; port?: number } = {},
+): Promise<Loopback> {
+  let resolveCode!: (code: string) => void;
+  let rejectCode!: (err: Error) => void;
+  const code = new Promise<string>((res, rej) => {
+    resolveCode = res;
+    rejectCode = rej;
+  });
+  // The consumer awaits `code` only after kicking off the authorization request (a
+  // network round-trip); a rejection landing before then must not become an
+  // unhandledRejection. This marks it handled; the consumer's own await still sees it.
+  code.catch(() => {});
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://${LOOPBACK_HOST}`);
+    if (url.pathname !== "/callback") {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const authCode = url.searchParams.get("code");
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(
+      `<html><body style="font-family:-apple-system,sans-serif;padding:3rem;background:#1c1c1c;color:#fafafa">` +
+        `<h2>${authCode ? "OpenTrade connected ✓" : "Authorization failed"}</h2>` +
+        `<p>You can close this tab and return to OpenTrade.</p></body></html>`,
+    );
+    if (authCode) resolveCode(authCode);
+    else
+      rejectCode(
+        new OAuthFlowError(
+          oauthErrorCode(url.searchParams.get("error")),
+          "authorization server returned an error",
+        ),
+      );
+  });
+
+  // A bind failure rejects *this* call (and, harmlessly, the pre-handled `code`);
+  // a later listener error rejects `code`.
+  await new Promise<void>((res, rej) => {
+    server.on("error", (err) => {
+      rej(err);
+      rejectCode(err);
+    });
+    server.listen(opts.port ?? 0, LOOPBACK_HOST, res);
+  });
+
+  const { port } = server.address() as AddressInfo;
+  const close = (reason: Error = new ConnectSuperseded()) => {
+    clearTimeout(timer);
+    rejectCode(reason); // no-op if `code` already settled
+    server.close(); // frees the port at once; a keep-alive socket drains on its own
+  };
+  const timer = setTimeout(
+    () => close(new OAuthFlowError("OAUTH_TIMEOUT", "consent flow timed out")),
+    opts.timeoutMs ?? CONSENT_TIMEOUT_MS,
+  );
+  return { redirectUrl: `http://${LOOPBACK_HOST}:${port}/callback`, code, close };
+}
 
 /**
  * Whether a failed token-authenticated connect means we should drop the stored
@@ -45,15 +166,13 @@ export interface RobinhoodAdapterOptions {
 
 export class RobinhoodAdapter implements BrokerAdapter {
   readonly id = "robinhood";
-  private provider: BrokerOAuthProvider;
+  protected provider: BrokerOAuthProvider;
   private client: Client | null = null;
+  /** The interactive consent currently waiting on the browser, if any. */
+  private pending: Loopback | null = null;
 
   constructor(opts: RobinhoodAdapterOptions) {
-    this.provider = new BrokerOAuthProvider({
-      db: opts.db,
-      redirectUrl: REDIRECT_URL,
-      openBrowser: opts.openBrowser,
-    });
+    this.provider = new BrokerOAuthProvider({ db: opts.db, openBrowser: opts.openBrowser });
   }
 
   isConnected(): boolean {
@@ -65,7 +184,9 @@ export class RobinhoodAdapter implements BrokerAdapter {
   }
 
   reset() {
+    this.cancelConnect();
     this.provider.reset();
+    void this.client?.close().catch(() => {});
     this.client = null;
   }
 
@@ -77,24 +198,34 @@ export class RobinhoodAdapter implements BrokerAdapter {
         await this.doConnect();
         return;
       } catch (err) {
-        if (!isReauthRequired(err)) throw err;
-        // The stored session is unusable (401, or the refresh token expired/was
-        // revoked → invalid_grant). Drop it so a later interactive connect starts
-        // clean — otherwise interactiveConnect's own doConnect would retry the same
-        // dead refresh and throw invalid_grant again.
-        this.provider.reset();
-        // Silent path (boot auto-connect): stay disconnected rather than pop a browser
-        // unprompted. The user re-consents explicitly via the Connect button.
-        if (!opts.interactive) return;
+        if (err instanceof ConsentRequired) {
+          // The SDK wanted a browser after a refresh failed for a *non*-grant reason
+          // (network, 5xx, no refresh token). Silent: keep the tokens — likely still
+          // good — and stay disconnected. Interactive: a fresh consent replaces them.
+          if (!opts.interactive) return;
+          this.provider.reset();
+        } else if (isReauthRequired(err)) {
+          // Dead session (401 / invalid_grant): drop it so an interactive connect
+          // starts clean instead of retrying the same dead refresh. Silent: stay
+          // disconnected rather than pop a browser unprompted.
+          this.provider.reset();
+          if (!opts.interactive) return;
+        } else {
+          throw err;
+        }
       }
     }
-    // Only the explicit Connect action opens a browser (fresh consent, or the
-    // re-consent after a dead grant above). A silent request with no usable session
-    // simply stays disconnected.
+    // Only the explicit Connect action opens a browser.
     if (opts.interactive) await this.interactiveConnect();
   }
 
-  private async doConnect(): Promise<void> {
+  /** Abandon the consent waiting on the browser, if any: its `connect()` rejects with `ConnectSuperseded`. */
+  cancelConnect(): void {
+    this.pending?.close();
+    this.pending = null;
+  }
+
+  protected async doConnect(): Promise<void> {
     const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL), {
       // biome-ignore lint/suspicious/noExplicitAny: provider matches SDK's structural OAuthClientProvider
       authProvider: this.provider as any,
@@ -104,8 +235,30 @@ export class RobinhoodAdapter implements BrokerAdapter {
     this.client = client;
   }
 
+  /** Exchange the loopback's authorization code for tokens (saved via the provider). */
+  protected async exchangeCode(code: string): Promise<void> {
+    const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL), {
+      // biome-ignore lint/suspicious/noExplicitAny: structural provider
+      authProvider: this.provider as any,
+    });
+    await transport.finishAuth(code);
+  }
+
+  /**
+   * The browser consent flow. Entered only with no usable tokens (fresh install, or
+   * after `connect()` dropped a dead/unrefreshable session), so the first `doConnect`
+   * is *expected* to end in a redirect: the SDK registers a client under this flow's
+   * loopback URL, opens the browser, and throws `UnauthorizedError`; the code then
+   * arrives on the loopback and is exchanged for tokens. Two flows must never overlap
+   * (both would write the same client-registration + PKCE rows and open a browser
+   * each) — `BrokerService.connect` guarantees that by cancelling and awaiting any
+   * pending connect before starting another; the cancel here is just hygiene.
+   */
   private async interactiveConnect(): Promise<void> {
-    const { server, codePromise } = this.startLoopback();
+    this.cancelConnect();
+    const loopback = await openLoopback();
+    this.pending = loopback;
+    this.provider.beginAuthorization(loopback.redirectUrl);
     try {
       try {
         await this.doConnect();
@@ -113,46 +266,14 @@ export class RobinhoodAdapter implements BrokerAdapter {
       } catch (err) {
         if (!isReauthRequired(err)) throw err;
       }
-      const code = await codePromise;
-      const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL), {
-        // biome-ignore lint/suspicious/noExplicitAny: structural provider
-        authProvider: this.provider as any,
-      });
-      await transport.finishAuth(code);
+      const code = await loopback.code;
+      await this.exchangeCode(code);
       await this.doConnect();
     } finally {
-      server.close();
+      this.provider.endAuthorization();
+      loopback.close();
+      if (this.pending === loopback) this.pending = null;
     }
-  }
-
-  private startLoopback(): { server: Server; codePromise: Promise<string> } {
-    let resolve!: (code: string) => void;
-    let reject!: (err: Error) => void;
-    const codePromise = new Promise<string>((res, rej) => {
-      resolve = res;
-      reject = rej;
-    });
-    const server = createServer((req, res) => {
-      const url = new URL(req.url ?? "/", REDIRECT_URL);
-      if (url.pathname !== "/callback") {
-        res.writeHead(404);
-        res.end();
-        return;
-      }
-      const code = url.searchParams.get("code");
-      const error = url.searchParams.get("error");
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(
-        `<html><body style="font-family:-apple-system,sans-serif;padding:3rem;background:#1c1c1c;color:#fafafa">` +
-          `<h2>${code ? "OpenTrade connected ✓" : "Authorization failed"}</h2>` +
-          `<p>You can close this tab and return to OpenTrade.</p></body></html>`,
-      );
-      if (code) resolve(code);
-      else reject(new Error(`oauth error: ${error ?? "unknown"}`));
-    });
-    server.on("error", (err) => reject(err));
-    server.listen(CALLBACK_PORT, "127.0.0.1");
-    return { server, codePromise };
   }
 
   private async call(name: string, args: Record<string, unknown> = {}): Promise<unknown> {

--- a/app/src/main/services/broker/robinhood/oauth.test.ts
+++ b/app/src/main/services/broker/robinhood/oauth.test.ts
@@ -1,0 +1,63 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import type { Db } from "../../../db/client";
+import * as schema from "../../../db/schema";
+import { BrokerOAuthProvider, ConsentRequired } from "./oauth";
+
+function memDb(): Db {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+  return drizzle(sqlite, { schema }) as unknown as Db;
+}
+
+function provider() {
+  const opened: string[] = [];
+  const p = new BrokerOAuthProvider({ db: memDb(), openBrowser: (u) => opened.push(u) });
+  return { p, opened };
+}
+
+const TOKENS = { access_token: "a", token_type: "bearer", refresh_token: "r" };
+
+describe("BrokerOAuthProvider", () => {
+  test("beginAuthorization adopts the loopback URL and drops the stale registration", () => {
+    const { p } = provider();
+    p.saveClientInformation({ client_id: "old" });
+    p.saveCodeVerifier("v-old");
+    p.saveTokens(TOKENS);
+    p.beginAuthorization("http://127.0.0.1:50123/callback");
+    // What the SDK reads: registration metadata + auth request + code exchange all
+    // agree on the freshly bound URL, and there's no client to reuse → re-register.
+    expect(p.redirectUrl).toBe("http://127.0.0.1:50123/callback");
+    expect(p.clientMetadata.redirect_uris).toEqual(["http://127.0.0.1:50123/callback"]);
+    expect(p.clientInformation()).toBeUndefined();
+    expect(() => p.codeVerifier()).toThrow();
+    // Tokens are left alone — dropping them is the adapter's call.
+    expect(p.hasTokens()).toBe(true);
+  });
+
+  test("outside a consent, redirectUrl is still a truthy string (SDK: not a non-interactive grant)", () => {
+    const { p } = provider();
+    expect(p.redirectUrl).toBeTruthy();
+    p.beginAuthorization("http://127.0.0.1:50123/callback");
+    p.endAuthorization();
+    expect(p.redirectUrl).toBeTruthy();
+    expect(p.redirectUrl).not.toBe("http://127.0.0.1:50123/callback");
+  });
+
+  test("the browser gate: silent throws ConsentRequired; inside a consent it opens", () => {
+    const { p, opened } = provider();
+    expect(() => p.redirectToAuthorization(new URL("https://robinhood.com/oauth"))).toThrow(
+      ConsentRequired,
+    );
+    expect(opened).toEqual([]);
+
+    p.beginAuthorization("http://127.0.0.1:50123/callback");
+    p.redirectToAuthorization(new URL("https://robinhood.com/oauth?x=1"));
+    expect(opened).toEqual(["https://robinhood.com/oauth?x=1"]);
+
+    p.endAuthorization();
+    expect(() => p.redirectToAuthorization(new URL("https://x"))).toThrow(ConsentRequired);
+    expect(opened).toHaveLength(1);
+  });
+});

--- a/app/src/main/services/broker/robinhood/oauth.ts
+++ b/app/src/main/services/broker/robinhood/oauth.ts
@@ -47,6 +47,29 @@ const K_TOKENS = "rh_oauth_tokens";
 const K_CLIENT = "rh_oauth_client";
 const K_VERIFIER = "rh_oauth_verifier";
 
+/**
+ * Reported as `redirectUrl` outside an interactive consent. The SDK only checks that
+ * a redirect URL is *present* on the token-refresh path (a missing one means a
+ * non-interactive grant flow); the value is never sent. Nothing listens here.
+ */
+const IDLE_REDIRECT_URL = "http://127.0.0.1/callback";
+
+/**
+ * Thrown by `redirectToAuthorization` when the MCP SDK wants to start a browser
+ * consent flow but the connect is *silent* (boot auto-connect). Opening a browser
+ * unprompted is never acceptable there, and the tokens on hand may still be fine
+ * (the SDK reaches this after a refresh failed for a *transient* reason — network,
+ * 5xx — not just a dead grant), so the caller keeps them and stays disconnected; the
+ * user re-consents explicitly via Connect. Distinct from `UnauthorizedError`, which
+ * the SDK throws only *after* it has already redirected.
+ */
+export class ConsentRequired extends Error {
+  constructor() {
+    super("browser consent required but the connect is not interactive");
+    this.name = "ConsentRequired";
+  }
+}
+
 // Minimal structural types mirroring the MCP SDK's OAuth shapes (avoids a hard
 // type import; the SDK validates these at runtime).
 interface OAuthTokens {
@@ -64,7 +87,6 @@ interface OAuthClientInformation {
 
 export interface OAuthProviderOptions {
   db: Db;
-  redirectUrl: string;
   /** Open the consent URL in the user's browser. */
   openBrowser: (url: string) => void;
 }
@@ -74,27 +96,55 @@ export interface OAuthProviderOptions {
  * registration + loopback redirect + PKCE, with tokens/client-info persisted as
  * plaintext in the app DB (0600; no safeStorage under ELECTRON_RUN_AS_NODE — see
  * SecureStore). Shape matches the MCP SDK's OAuthClientProvider.
+ *
+ * The redirect URL is **per consent**, not a constant: each interactive consent binds
+ * a fresh ephemeral loopback port, and the adapter calls `beginAuthorization(url)`
+ * with it before the SDK registers the client. The SDK reads `redirectUrl` at
+ * registration, in the authorization request, and at code exchange — all inside that
+ * one flow, so they agree and match what Robinhood has on file.
  */
 export class BrokerOAuthProvider {
   private store: SecureStore;
+  /**
+   * The loopback URL of the interactive consent in progress; null otherwise. Doubles
+   * as the browser gate: the SDK may only open a browser while this is set.
+   */
+  private activeRedirectUrl: string | null = null;
 
   constructor(private opts: OAuthProviderOptions) {
     this.store = new SecureStore(opts.db);
   }
 
   get redirectUrl(): string {
-    return this.opts.redirectUrl;
+    return this.activeRedirectUrl ?? IDLE_REDIRECT_URL;
   }
 
   get clientMetadata() {
     return {
       client_name: "OpenTrade (read-only portfolio client)",
-      redirect_uris: [this.opts.redirectUrl],
+      redirect_uris: [this.redirectUrl],
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: "none",
       scope: "read",
     };
+  }
+
+  /**
+   * Start an interactive consent on a freshly bound loopback: adopt its redirect URL
+   * and drop any stored client registration so the SDK registers a new client under
+   * this URL (one made for a different port would fail with redirect_uri mismatch).
+   * Tokens are left alone — dropping them is the adapter's call.
+   */
+  beginAuthorization(redirectUrl: string) {
+    this.store.clear(K_CLIENT);
+    this.store.clear(K_VERIFIER);
+    this.activeRedirectUrl = redirectUrl;
+  }
+
+  /** The interactive consent ended (however it ended): the browser gate closes again. */
+  endAuthorization() {
+    this.activeRedirectUrl = null;
   }
 
   state() {
@@ -117,7 +167,14 @@ export class BrokerOAuthProvider {
     this.store.setSecret(K_TOKENS, tokens);
   }
 
+  /**
+   * The SDK wants the user to consent in a browser. Only an interactive connect may
+   * open one; a silent connect (boot) that lands here throws `ConsentRequired` so the
+   * caller stays disconnected — with its tokens — instead of popping a browser
+   * unprompted onto a redirect URL nobody is listening on.
+   */
   redirectToAuthorization(url: URL) {
+    if (!this.activeRedirectUrl) throw new ConsentRequired();
     this.opts.openBrowser(url.toString());
   }
 

--- a/app/src/main/trpc/routers/broker.ts
+++ b/app/src/main/trpc/routers/broker.ts
@@ -19,6 +19,12 @@ export const brokerRouter = router({
     .input(z.object({ symbol: z.string(), maxAgeMs: z.number().default(5000) }))
     .query(({ ctx, input }) => ctx.broker.getQuote(input.symbol, input.maxAgeMs)),
 
+  /** Reset/Disconnect: abandon a pending consent, forget the session (§6.6). */
+  disconnect: publicProcedure.mutation(async ({ ctx }) => {
+    await ctx.broker.disconnect();
+    return { status: ctx.broker.getStatus() };
+  }),
+
   refreshNow: publicProcedure.mutation(async ({ ctx }) => {
     await ctx.broker.getPositionsLive(0);
     return { ok: true };

--- a/app/src/renderer/components/panels/Portfolio.tsx
+++ b/app/src/renderer/components/panels/Portfolio.tsx
@@ -13,6 +13,7 @@ const MASK = "****";
 export function Portfolio() {
   const status = useBrokerStatus();
   const connect = trpc.onboarding.connectBroker.useMutation();
+  const disconnect = trpc.broker.disconnect.useMutation();
   const data = useBrokerData();
   const balancesHidden = useUIStore((s) => s.balancesHidden);
   const toggleBalances = useUIStore((s) => s.toggleBalances);
@@ -42,8 +43,18 @@ export function Portfolio() {
 
   if (status.status === "connecting") {
     return (
-      <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
-        <Loader2 className="size-4 animate-spin" /> Connecting…
+      <div className="flex items-center gap-3 p-4 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" /> Waiting for Robinhood…
+        {/* The consent can't tell the browser tab was closed; Cancel is the way out. */}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disconnect.isPending}
+          onClick={() => disconnect.mutate()}
+        >
+          Cancel
+        </Button>
       </div>
     );
   }

--- a/app/src/renderer/screens/Onboarding.tsx
+++ b/app/src/renderer/screens/Onboarding.tsx
@@ -6,6 +6,7 @@ import { Card } from "../components/ui/card";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import { useTrackEvent } from "../hooks/useAnalytics";
+import { useBrokerStatus } from "../hooks/useBroker";
 import { useUpdateSettings } from "../hooks/useSettings";
 import { trpc } from "../lib/trpc";
 import { cn } from "../lib/utils";
@@ -177,12 +178,18 @@ function ClaudeStep({ onNext }: { onNext: () => void }) {
 }
 
 function BrokerStep({ onNext }: { onNext: () => void }) {
-  const status = trpc.broker.connectionStatus.useQuery();
+  const status = useBrokerStatus();
   const utils = trpc.useUtils();
   const connect = trpc.onboarding.connectBroker.useMutation({
     onSuccess: () => utils.broker.connectionStatus.invalidate(),
   });
-  const connected = status.data?.status === "connected";
+  const disconnect = trpc.broker.disconnect.useMutation({
+    onSuccess: () => utils.broker.connectionStatus.invalidate(),
+  });
+  const connected = status?.status === "connected";
+  // Status-driven too, not just this mutation: a consent started before a remount /
+  // GUI restart is still pending in the daemon, and Settings isn't reachable from here.
+  const connecting = connect.isPending || status?.status === "connecting";
 
   return (
     <div className="flex flex-col gap-4">
@@ -199,26 +206,41 @@ function BrokerStep({ onNext }: { onNext: () => void }) {
         // row on the left, the status indicator sits right.
         <div className="flex items-center justify-between rounded-md border border-border bg-background px-3 py-2 text-sm">
           <span className="text-muted-foreground">
-            {status.data?.account &&
-              `${status.data.account.agentic ? "agentic" : status.data.account.type} ${status.data.account.accountNumber}`}
+            {status?.account &&
+              `${status.account.agentic ? "agentic" : status.account.type} ${status.account.accountNumber}`}
           </span>
           <span className="flex items-center gap-2 text-success">
             <Check className="size-4" /> Connected
           </span>
         </div>
+      ) : connecting ? (
+        <div className="flex items-center justify-between rounded-md border border-border bg-background px-3 py-2 text-sm">
+          <span className="flex items-center gap-2 text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" /> Waiting for you to approve in the browser…
+          </span>
+          {/* The consent can't tell the browser tab was closed; without this the daemon
+              waits out its timeout and the user is stuck here. */}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disconnect.isPending}
+            onClick={() => disconnect.mutate()}
+          >
+            Cancel
+          </Button>
+        </div>
       ) : (
         <Button
           type="button"
-          disabled={connect.isPending}
           onClick={() => connect.mutate()}
           className="justify-center gap-2 py-2"
         >
-          {connect.isPending && <Loader2 className="size-4 animate-spin" />}
           Connect Robinhood
         </Button>
       )}
 
-      {connect.isError && (
+      {connect.isError && !connecting && (
         <p className="text-xs text-destructive">Connection failed. You can try again.</p>
       )}
 

--- a/app/src/renderer/screens/Settings.tsx
+++ b/app/src/renderer/screens/Settings.tsx
@@ -351,14 +351,18 @@ function BrokerConnectionRow() {
   const connect = trpc.onboarding.connectBroker.useMutation({
     onSuccess: () => utils.broker.connectionStatus.invalidate(),
   });
+  const disconnect = trpc.broker.disconnect.useMutation({
+    onSuccess: () => utils.broker.connectionStatus.invalidate(),
+  });
   const st = status?.status ?? "disconnected";
   const account = status?.account;
+  const connecting = connect.isPending || st === "connecting";
 
   const hint =
     st === "connected" && account
       ? `${account.agentic ? "agentic" : account.type} · ${account.accountNumber}`
-      : st === "connecting"
-        ? "Connecting…"
+      : connecting
+        ? "Waiting for you to approve in the browser. Closed the tab? Cancel and connect again."
         : "Not connected";
 
   return (
@@ -366,16 +370,39 @@ function BrokerConnectionRow() {
       <div className="flex items-center gap-2.5">
         <span className={cn("size-2 shrink-0 rounded-full", STATUS_DOT[st])} />
         {st === "connected" ? (
-          <span className="text-sm text-muted-foreground">Connected</span>
+          <>
+            <span className="text-sm text-muted-foreground">Connected</span>
+            {/* Forget the session: the next Connect is a fresh consent (also how to
+                switch Robinhood accounts). */}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={disconnect.isPending}
+              onClick={() => disconnect.mutate()}
+            >
+              Disconnect
+            </Button>
+          </>
+        ) : connecting ? (
+          <>
+            <span className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" /> Waiting for Robinhood…
+            </span>
+            {/* The consent flow can't tell that the browser tab was closed; this is the
+                way out (the daemon otherwise waits out its timeout). */}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={disconnect.isPending}
+              onClick={() => disconnect.mutate()}
+            >
+              Cancel
+            </Button>
+          </>
         ) : (
-          <Button
-            type="button"
-            disabled={connect.isPending || st === "connecting"}
-            onClick={() => connect.mutate()}
-          >
-            {(connect.isPending || st === "connecting") && (
-              <Loader2 className="size-4 animate-spin" />
-            )}
+          <Button type="button" onClick={() => connect.mutate()}>
             {st === "error" ? "Retry" : "Connect"}
           </Button>
         )}

--- a/app/src/shared/analytics.ts
+++ b/app/src/shared/analytics.ts
@@ -29,6 +29,14 @@ import { NotificationKind } from "./notify";
 /** A bare identifier — an Error class name. Cannot carry a message/stack/path. */
 const errorName = z.string().regex(/^[A-Za-z0-9_$]{1,64}$/);
 
+/**
+ * A machine error code — `err.code` when it is a bare identifier (Node system codes
+ * like `EADDRINUSE`/`ECONNREFUSED`, `ERR_*`, our own `OAUTH_*`). Bounded token, no
+ * spaces: structurally unable to carry a message. It's the one field that turns a
+ * bare `Error` (whose class name says nothing) into something diagnosable.
+ */
+const errorCode = z.string().regex(/^[A-Za-z0-9_]{1,48}$/);
+
 /** A semver-ish version string. */
 const version = z.string().regex(/^\d+\.\d+\.\d+(?:-[\w.]+)?$/);
 
@@ -142,7 +150,10 @@ export const TELEMETRY_EVENTS = {
 
   // broker
   broker_connected: z.strictObject({}),
-  broker_connect_failed: z.strictObject({ error_name: errorName }),
+  broker_connect_failed: z.strictObject({
+    error_name: errorName,
+    error_code: errorCode.optional(),
+  }),
 
   // autonomy
   schedule_created: z.strictObject({
@@ -175,6 +186,7 @@ export const TELEMETRY_EVENTS = {
   app_error: z.strictObject({
     subsystem: ErrorSubsystem,
     error_name: errorName,
+    error_code: errorCode.optional(),
     source: ErrorSource.optional(),
     frames: frames.optional(),
   }),
@@ -289,4 +301,16 @@ export function errorNameOf(err: unknown): string {
   // Keep only identifier chars; guarantee the `errorName` regex passes.
   const clean = name.replace(/[^A-Za-z0-9_$]/g, "").slice(0, 64);
   return clean || "Error";
+}
+
+/**
+ * The machine code of a thrown value (`err.code`), or undefined unless it *already*
+ * fits the `errorCode` shape — nothing is coerced or truncated into one, so a `code`
+ * holding a message/path is dropped, not leaked. Numeric codes (DOMException) are
+ * ignored: meaningless without the class name, which `errorNameOf` carries.
+ */
+export function errorCodeOf(err: unknown): string | undefined {
+  const code =
+    typeof err === "object" && err !== null ? (err as { code?: unknown }).code : undefined;
+  return errorCode.safeParse(code).success ? (code as string) : undefined;
 }


### PR DESCRIPTION
## Why

PostHog showed a new user (`61a46e1a…`, v0.2.2, 2026-08-17) hitting two `app_error {subsystem: host, error_name: Error, source: unhandled_rejection}` events ~25s apart during onboarding, each followed ~2s later by `broker_connect_failed`. They never got `broker_connected` and finished onboarding without a broker. Telemetry carried no `frames` (a Node system error's stack is all `node:internal`) and no code, so it couldn't say what happened.

Root cause chain (traced in code, reproduced locally):

1. `robinhood/client.ts` bound the OAuth loopback on **fixed port 8771** and the listener's `error` rejected `codePromise` **before anyone awaited it** (the flow was mid-`doConnect`) → `unhandledRejection` → the `host/Error` `app_error`. Then the browser opened anyway onto a dead redirect.
2. `BrokerService.connect` guarded only `"connected"`, not `"connecting"` → a second Connect (a remounted Onboarding — this user's `onboarding_started` fired twice — or Settings/Portfolio) collided with a still-pending flow → `EADDRINUSE`.
3. The loopback wait had **no timeout and no cancellation** → closing the consent tab left the flow + port hung for the life of the host, failing every later Connect.
4. `err.code` was never captured; `app_error` is a `strictObject`.

## What

- **`openLoopback()`** — ephemeral `127.0.0.1` port (RFC 8252 §7.3), resolves only once listening (bind failure = ordinary rejection *before* any browser), pre-handled code rejection, 10-min timeout (`OAuthFlowError OAUTH_TIMEOUT`), RFC 6749 callback errors → `OAUTH_<ERROR>` from a closed whitelist, `close()` cancels.
- **Supersede on re-click** — `BrokerService.connect` is the single serialization point: silent joins the in-flight connect; interactive calls `adapter.cancelConnect()` (rejects the pending flow with `ConnectSuperseded`, releases its loopback), waits for it to unwind, restarts. A superseded call resolves quietly (no failure event, no status change).
- **Redirect URL is per consent** — `provider.beginAuthorization(url)` adopts the loopback URL in memory and drops the stored client registration so the SDK re-registers under it (a mismatched port is rejected by Robinhood). Outside a flow the provider reports a placeholder: the SDK only checks presence on the refresh path and never sends it, so nothing is persisted and upgraded installs refresh untouched.
- **Browser gate** — `redirectToAuthorization` only opens the browser inside an interactive consent, else throws `ConsentRequired`; the silent boot path no longer pops a tab unprompted, and **keeps tokens** a transient refresh failure didn't actually kill.
- **`error_code`** on `app_error` + `broker_connect_failed` — `err.code` when it's a bare identifier (`errorCodeOf`), e.g. `EADDRINUSE`, `OAUTH_ACCESS_DENIED`.
- **Reset / Cancel** (third commit) — `BrokerService.disconnect()` ← `broker.disconnect`: cancels a pending consent, forgets the session, status → `disconnected`. Surfaced as **Cancel** next to a "Waiting for Robinhood…" spinner on all three Connect surfaces (Onboarding — where Settings isn't reachable —, Portfolio panel, Settings) and **Disconnect** in Settings when connected. The consent can't tell the browser tab was closed; before this the daemon waited out the timeout with the UI stuck on "connecting", GUI restart or not.

Verified live that Robinhood's DCR endpoint accepts and echoes an arbitrary loopback port (`127.0.0.1:53127` → 200).

Second commit simplifies per an over-engineering review (single serialization level, in-memory redirect URL, whitelist error codes, leaner loopback internals, dead fields + duplicate tests removed) — no behaviour change.

## Tests

270/270 (`bun test`), typecheck clean, lint identical to `main`. New/extended: loopback behaviour (incl. an explicit no-`unhandledRejection` check and `EADDRINUSE` surfacing at bind), adapter silent/interactive branching, full consent flow + supersede, provider browser gate, service serialization + telemetry, disconnect while pending / connected / idle.

## Not verified here

The end-to-end Robinhood consent (a real browser login) — I can't consent from this session. The interactive path is exercised against stubbed `doConnect`/`exchangeCode` with the real loopback + provider + branching. Please run one real Connect from the app before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
