### PR TITLE
Broker telemetry: network outages aren't app errors, cause.code, connect funnel, browser-launch failures

### DIFF
--- a/app/src/main/host/index.ts
+++ b/app/src/main/host/index.ts
@@ -43,12 +43,19 @@ import { hostLog } from "./log";
 import { clearManifest, writeManifest } from "./manifest";
 import { HostTrpcServer } from "./trpc-server";
 
-/** Open a URL in the user's browser headlessly (no Electron shell). */
+/**
+ * Open a URL in the user's browser headlessly (no Electron shell). Its only caller is
+ * the broker's OAuth consent, so a failure is reported under `broker`: without that, a
+ * consent whose tab never opened is indistinguishable in telemetry from one the user
+ * abandoned (both end in `OAUTH_TIMEOUT`).
+ */
 function openExternal(url: string): void {
   const cmd =
     process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
   execFile(cmd, [url], (err) => {
-    if (err) hostLog.error("openExternal failed", String(err));
+    if (!err) return;
+    hostLog.error("openExternal failed", String(err));
+    analytics.trackError("broker", err, "caught");
   });
 }
 

--- a/app/src/main/services/analytics/analytics.test.ts
+++ b/app/src/main/services/analytics/analytics.test.ts
@@ -281,6 +281,38 @@ describe("analytics allowlist + normalizers", () => {
     ).toBe(true);
   });
 
+  test("errorCodeOf falls back to err.cause.code — the undici `fetch failed` shape", () => {
+    // What `fetch` throws on a network failure: a bare TypeError with the real code one
+    // level down. These are the exact shapes Node 22 produces (probed, not assumed).
+    const dns = new TypeError("fetch failed", {
+      cause: Object.assign(new Error("getaddrinfo ENOTFOUND agent.robinhood.com"), {
+        code: "ENOTFOUND",
+      }),
+    });
+    expect(errorCodeOf(dns)).toBe("ENOTFOUND");
+    // Dual-stack host: the cause is an AggregateError that Node also stamps with the code.
+    const refused = new TypeError("fetch failed", {
+      cause: Object.assign(new AggregateError([], "connect ECONNREFUSED"), {
+        code: "ECONNREFUSED",
+      }),
+    });
+    expect(errorCodeOf(refused)).toBe("ECONNREFUSED");
+    // Own code wins over the cause's; a cause with no code adds nothing; one level only.
+    expect(
+      errorCodeOf(Object.assign(new Error("x"), { code: "OWN", cause: { code: "INNER" } })),
+    ).toBe("OWN");
+    expect(
+      errorCodeOf(new TypeError("fetch failed", { cause: new Error("bad port") })),
+    ).toBeUndefined();
+    expect(
+      errorCodeOf(new Error("x", { cause: new Error("y", { cause: { code: "DEEP" } }) })),
+    ).toBeUndefined();
+    // The same sanitization applies to the cause's code.
+    expect(
+      errorCodeOf(new Error("x", { cause: { code: "not an identifier /path" } })),
+    ).toBeUndefined();
+  });
+
   test("app_error source accepts the enum and rejects free text", () => {
     const ok = TELEMETRY_EVENTS.app_error.safeParse({
       subsystem: "renderer",

--- a/app/src/main/services/broker/connect.test.ts
+++ b/app/src/main/services/broker/connect.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import type { Account } from "@shared/broker";
+import type { Account, OrderStatus, Portfolio, Position, Quote } from "@shared/broker";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import type { Db } from "../../db/client";
 import * as schema from "../../db/schema";
@@ -67,8 +67,25 @@ class FakeAdapter {
     this.cancelConnect();
     this.connected = false;
   }
+  /** Set to make the service pick an account and start polling. */
+  account: Account | null = null;
   async listAccounts(): Promise<Account[]> {
+    return this.account ? [this.account] : [];
+  }
+  // ---- the poll's reads: `pollScript` decides whether a poll succeeds or how it fails ----
+  pollScript: () => Promise<void> = async () => {};
+  async getPortfolio(): Promise<Portfolio> {
+    await this.pollScript();
+    return {} as Portfolio;
+  }
+  async getPositions(): Promise<Position[]> {
     return [];
+  }
+  async getQuotes(): Promise<Quote[]> {
+    return [];
+  }
+  async getAgenticOrders(): Promise<{ orders: OrderStatus[]; cursor: string | null }> {
+    return { orders: [], cursor: null };
   }
 }
 
@@ -249,5 +266,152 @@ describe("BrokerService.connect — failure telemetry", () => {
     const failed = client.events.find((e) => e.event === "broker_connect_failed");
     expect(failed?.properties).toMatchObject({ error_name: "TypeError" });
     expect(failed?.properties).not.toHaveProperty("error_code");
+  });
+});
+
+describe("BrokerService.connect — the funnel", () => {
+  test("every attempt opens with broker_connect_started {mode}", async () => {
+    const { svc, adapter, client } = setup();
+    const silent = svc.connect();
+    await tick();
+    adapter.fail(0, new Error("no session"));
+    await silent.catch(() => {});
+    const click = svc.connect({ interactive: true });
+    await tick();
+    adapter.succeed(1);
+    await click;
+    const started = client.events.filter((e) => e.event === "broker_connect_started");
+    expect(started.map((e) => e.properties?.mode)).toEqual(["silent", "interactive"]);
+    // Outcomes still close the funnel as before.
+    expect(client.events.map((e) => e.event)).toContain("broker_connect_failed");
+    expect(client.events.map((e) => e.event)).toContain("broker_connected");
+  });
+});
+
+/** The undici shape the poll loop actually catches on a network drop. */
+const fetchFailed = (code: string) =>
+  new TypeError("fetch failed", { cause: Object.assign(new Error(code), { code }) });
+
+/** Connect with an account so polling is live, then return the service + adapter. */
+async function connectedWithAccount() {
+  const s = setup();
+  s.adapter.account = { accountNumber: "A1", agentic: true } as Account;
+  const c = s.svc.connect();
+  await tick();
+  s.adapter.succeed(0);
+  await c;
+  expect(s.svc.getStatus()).toBe("connected");
+  s.client.events.length = 0; // look only at what polling produces from here
+  return s;
+}
+/** Drive one poll. (maxAge 0 is "cache older than now" — let the clock tick past the
+ *  previous poll's write first, or it short-circuits to the cache within the same ms.) */
+const poll = async (svc: BrokerService) => {
+  await new Promise((r) => setTimeout(r, 2));
+  await svc.getPositionsLive(0);
+};
+const events = (client: { events: { event: string }[] }) => client.events.map((e) => e.event);
+
+describe("BrokerService poll loop — network outages are not app errors", () => {
+  test("a transient network failure → one broker_offline, no app_error", async () => {
+    const { svc, adapter, client } = await connectedWithAccount();
+    adapter.pollScript = async () => {
+      throw fetchFailed("ECONNRESET");
+    };
+    await poll(svc);
+    expect(events(client)).toEqual(["broker_offline"]);
+    expect(client.events[0].properties).toMatchObject({ error_code: "ECONNRESET" });
+    // Status is untouched: the panel keeps showing cached data.
+    expect(svc.getStatus()).toBe("connected");
+  });
+
+  test("consecutive failures in one outage stay one event; recovery emits broker_online with counts", async () => {
+    const { svc, adapter, client } = await connectedWithAccount();
+    // Last night's shape: 5 failed polls in a row while the laptop's Wi‑Fi came back.
+    adapter.pollScript = async () => {
+      throw fetchFailed("ENOTFOUND");
+    };
+    for (let i = 0; i < 5; i++) await poll(svc);
+    expect(events(client)).toEqual(["broker_offline"]);
+    // Network is back.
+    adapter.pollScript = async () => {};
+    await poll(svc);
+    expect(events(client)).toEqual(["broker_offline", "broker_online"]);
+    expect(client.events[1].properties).toMatchObject({ failed_polls: 5 });
+    expect(client.events[1].properties?.offline_ms).toBeGreaterThanOrEqual(0);
+    // A second, separate outage reports again.
+    adapter.pollScript = async () => {
+      throw fetchFailed("ECONNREFUSED");
+    };
+    await poll(svc);
+    expect(events(client)).toEqual(["broker_offline", "broker_online", "broker_offline"]);
+    expect(client.events[2].properties).toMatchObject({ error_code: "ECONNREFUSED" });
+  });
+
+  test("healthy polls emit nothing", async () => {
+    const { svc, client } = await connectedWithAccount();
+    await poll(svc);
+    await poll(svc);
+    expect(events(client)).toEqual([]);
+  });
+
+  test("a non-network failure is still an app_error — every time", async () => {
+    const { svc, adapter, client } = await connectedWithAccount();
+    // e.g. a mapping bug thrown from our own code.
+    adapter.pollScript = async () => {
+      throw new TypeError("Cannot read properties of undefined (reading 'equity')");
+    };
+    await poll(svc);
+    await poll(svc);
+    expect(events(client)).toEqual(["app_error", "app_error"]);
+    expect(client.events[0].properties).toMatchObject({
+      subsystem: "broker",
+      error_name: "TypeError",
+      source: "caught",
+    });
+  });
+
+  test("disconnect closes the books: no broker_online spanning a deliberate disconnect", async () => {
+    const { svc, adapter, client } = await connectedWithAccount();
+    adapter.pollScript = async () => {
+      throw fetchFailed("ECONNRESET");
+    };
+    await poll(svc);
+    await svc.disconnect();
+    // Reconnect and poll fine: no stale broker_online from the pre-disconnect outage.
+    adapter.pollScript = async () => {};
+    const again = svc.connect();
+    await tick();
+    adapter.succeed(1);
+    await again;
+    await poll(svc);
+    expect(events(client).filter((e) => e === "broker_online")).toEqual([]);
+  });
+
+  test("a poll in flight when disconnect() runs reports nothing and doesn't reopen tracking", async () => {
+    const { svc, adapter, client } = await connectedWithAccount();
+    // Hold a poll mid-request, disconnect under it, then let it fail (as its closed
+    // client would make it): no app_error, no broker_offline, and a later reconnect's
+    // first good poll must not emit a broker_online spanning the disconnect.
+    let failPoll!: () => void;
+    adapter.pollScript = () =>
+      new Promise<void>((_, reject) => {
+        failPoll = () => reject(fetchFailed("ECONNRESET"));
+      });
+    const inflight = poll(svc);
+    await new Promise((r) => setTimeout(r, 5));
+    await svc.disconnect();
+    failPoll();
+    await inflight;
+    expect(events(client)).toEqual([]);
+    adapter.pollScript = async () => {};
+    const again = svc.connect();
+    await tick();
+    adapter.succeed(1);
+    await again;
+    await poll(svc);
+    expect(
+      events(client).filter((e) => e !== "broker_connect_started" && e !== "broker_connected"),
+    ).toEqual([]);
   });
 });

--- a/app/src/main/services/broker/index.ts
+++ b/app/src/main/services/broker/index.ts
@@ -14,6 +14,7 @@ import { analytics } from "../analytics";
 import { bus } from "../event-bus";
 import type { SettingsService } from "../settings";
 import { type BrokerAdapter, ConnectSuperseded } from "./adapter";
+import { isTransientNetworkError } from "./network-error";
 import { orderNotification, terminalTransition } from "./order-notify";
 
 /**
@@ -140,6 +141,9 @@ export class BrokerService {
 
   private async runConnect(opts: { interactive?: boolean }): Promise<void> {
     this.setStatus("connecting");
+    analytics.track("broker_connect_started", {
+      mode: opts.interactive ? "interactive" : "silent",
+    });
     try {
       await this.adapter.connect(opts);
       // A silent connect can end without a session — the stored grant was dead and the
@@ -185,6 +189,8 @@ export class BrokerService {
     this.adapter.reset();
     this.account = null;
     this.ledger.clear();
+    this.offlineSince = null; // an outage doesn't span a deliberate disconnect
+    this.failedPolls = 0;
     this.setStatus("disconnected");
   }
 
@@ -271,12 +277,42 @@ export class BrokerService {
       updated.push("agentic_orders");
 
       bus.emitEvent("broker:updated", { keys: updated });
+      this.noteOnline();
     } catch (err) {
       console.error("[broker] poll failed", err);
-      analytics.trackError("broker", err, "caught");
+      // A poll that was in flight when disconnect() ran fails by design (its client was
+      // closed under it) — nothing to report, and it must not reopen outage tracking.
+      if (this.status !== "connected") return;
+      // Network outage (laptop sleep/wake, Wi‑Fi blip) → broker_offline; else app_error.
+      if (isTransientNetworkError(err)) this.noteOffline(err);
+      else analytics.trackError("broker", err, "caught");
     } finally {
       this.polling = false;
     }
+  }
+
+  // ---- outage tracking (poll loop) ----
+
+  /** When the current network outage began (first failed poll), or null if online. */
+  private offlineSince: number | null = null;
+  private failedPolls = 0;
+
+  private noteOffline(err: unknown) {
+    this.failedPolls++;
+    if (this.offlineSince !== null) return;
+    this.offlineSince = Date.now();
+    const code = errorCodeOf(err);
+    analytics.track("broker_offline", code ? { error_code: code } : {});
+  }
+
+  private noteOnline() {
+    if (this.offlineSince === null) return;
+    analytics.track("broker_online", {
+      offline_ms: Date.now() - this.offlineSince,
+      failed_polls: this.failedPolls,
+    });
+    this.offlineSince = null;
+    this.failedPolls = 0;
   }
 
   // ---- reads (cache-first) ----

--- a/app/src/main/services/broker/network-error.test.ts
+++ b/app/src/main/services/broker/network-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { isTransientNetworkError } from "./network-error";
+
+// The shape Node's undici `fetch` throws on a network failure — a bare
+// `TypeError: fetch failed` with the code on `.cause` — as probed under Node 22 (the
+// host runs Electron's Node). Constructed rather than fetched live: bun's own `fetch`
+// throws a different shape, so a live probe here would test the wrong runtime.
+const withCause = (code: string) =>
+  new TypeError("fetch failed", { cause: Object.assign(new Error(code), { code }) });
+
+describe("isTransientNetworkError", () => {
+  test("the sleep/wake family — code on the cause, as undici reports it", () => {
+    for (const code of [
+      "ENOTFOUND",
+      "EAI_AGAIN",
+      "ECONNRESET",
+      "ETIMEDOUT",
+      "ENETUNREACH",
+      "EHOSTUNREACH",
+      "UND_ERR_CONNECT_TIMEOUT",
+      "UND_ERR_SOCKET",
+    ]) {
+      expect(isTransientNetworkError(withCause(code))).toBe(true);
+    }
+    // …and on the error itself (a raw socket error surfacing without a fetch wrapper).
+    expect(
+      isTransientNetworkError(Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" })),
+    ).toBe(true);
+    // A bare `fetch failed` with an unrecognized cause is still transport-level.
+    expect(isTransientNetworkError(new TypeError("fetch failed", { cause: new Error("?") }))).toBe(
+      true,
+    );
+  });
+
+  test("not transient: bugs, protocol errors, HTTP failures, other codes", () => {
+    // A mapping bug in our own code is a TypeError too — but not `fetch failed`.
+    expect(isTransientNetworkError(new TypeError("Cannot read properties of undefined"))).toBe(
+      false,
+    );
+    expect(isTransientNetworkError(new McpError(-32601, "Method not found"))).toBe(false);
+    expect(
+      isTransientNetworkError(Object.assign(new Error("listen"), { code: "EADDRINUSE" })),
+    ).toBe(false);
+    expect(isTransientNetworkError(new Error("broker not connected"))).toBe(false);
+    expect(isTransientNetworkError(null)).toBe(false);
+    expect(isTransientNetworkError("ECONNRESET")).toBe(false);
+  });
+});

--- a/app/src/main/services/broker/network-error.ts
+++ b/app/src/main/services/broker/network-error.ts
@@ -1,0 +1,35 @@
+import { errorCodeOf } from "@shared/analytics";
+
+/** "The network is not there right now" — DNS, connect/reset/timeout, unreachable, undici's own. */
+const TRANSIENT_NETWORK_CODES = new Set([
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ECONNABORTED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "ENETUNREACH",
+  "ENETDOWN",
+  "EHOSTUNREACH",
+  "EHOSTDOWN",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+]);
+
+/**
+ * Is this failure a transient network outage — what a laptop produces around
+ * sleep/wake, a Wi‑Fi handoff, a VPN flap — as opposed to a bug, a protocol error, or
+ * the server rejecting us? True for a code in the set above (on the error or, as undici
+ * does it, on its `cause`) and for a bare `TypeError: fetch failed` whose cause we don't
+ * recognize (still transport-level, never app logic; nothing in our bundle produces that
+ * message). Anything else — a mapping TypeError from our code, an `McpError`, an HTTP
+ * error class — is not transient and stays an `app_error`.
+ */
+export function isTransientNetworkError(err: unknown): boolean {
+  const code = errorCodeOf(err);
+  if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;
+  return err instanceof TypeError && err.message === "fetch failed";
+}

--- a/app/src/shared/analytics.ts
+++ b/app/src/shared/analytics.ts
@@ -149,10 +149,24 @@ export const TELEMETRY_EVENTS = {
   order_submit_resolved: z.strictObject({ result: z.enum(["ok", "rejected", "unknown"]) }),
 
   // broker
+  /** Top of the connect funnel; `connected` / `connect_failed` are the outcomes. The gap
+   *  is attempts with no outcome event: superseded by a later click, still pending, or a
+   *  silent connect that found a dead grant and quietly stayed disconnected. */
+  broker_connect_started: z.strictObject({ mode: z.enum(["interactive", "silent"]) }),
   broker_connected: z.strictObject({}),
   broker_connect_failed: z.strictObject({
     error_name: errorName,
     error_code: errorCode.optional(),
+  }),
+  /**
+   * The poll loop lost the network (laptop sleep/wake, Wi‑Fi blip): once per outage,
+   * with the first failure's code, instead of an `app_error` per failed poll. Not an
+   * error in the app — filter it out of error dashboards. `broker_online` closes it.
+   */
+  broker_offline: z.strictObject({ error_code: errorCode.optional() }),
+  broker_online: z.strictObject({
+    offline_ms: z.number().int().nonnegative(),
+    failed_polls: z.number().int().nonnegative(),
   }),
 
   // autonomy
@@ -304,13 +318,21 @@ export function errorNameOf(err: unknown): string {
 }
 
 /**
- * The machine code of a thrown value (`err.code`), or undefined unless it *already*
- * fits the `errorCode` shape — nothing is coerced or truncated into one, so a `code`
- * holding a message/path is dropped, not leaked. Numeric codes (DOMException) are
- * ignored: meaningless without the class name, which `errorNameOf` carries.
+ * The machine code of a thrown value — `err.code`, or failing that `err.cause.code` —
+ * or undefined unless it *already* fits the `errorCode` shape: nothing is coerced or
+ * truncated into one, so a `code` holding a message/path is dropped, not leaked.
+ * Numeric codes (DOMException) are ignored: meaningless without the class name, which
+ * `errorNameOf` carries.
+ *
+ * The `cause` hop is for undici: every network failure `fetch` throws is a bare
+ * `TypeError: fetch failed` with no code of its own — the useful token
+ * (`ENOTFOUND`, `ECONNRESET`, `ECONNREFUSED`, `UND_ERR_CONNECT_TIMEOUT`, …) sits on
+ * `.cause` (Node also copies it onto the `AggregateError` for dual-stack hosts). One
+ * level only.
  */
 export function errorCodeOf(err: unknown): string | undefined {
-  const code =
-    typeof err === "object" && err !== null ? (err as { code?: unknown }).code : undefined;
+  const codeOn = (v: unknown) =>
+    typeof v === "object" && v !== null ? (v as { code?: unknown }).code : undefined;
+  const code = codeOn(err) ?? codeOn((err as { cause?: unknown } | null)?.cause);
   return errorCode.safeParse(code).success ? (code as string) : undefined;
 }


### PR DESCRIPTION
## Why

Triaging 0.2.3's first day of telemetry surfaced three blind spots:

- **Laptop sleep/wake looked like a bug.** A new user's host emitted 5 `app_error {broker, TypeError}` in 40 s (one per poll at the blurred 10 s cadence) while their Wi‑Fi came back — no `frames` (thrown outside our bundle), no `error_code`. Same signature on my own machine every nap. This *will* happen on laptops; it shouldn't read as an app error, and it should be filterable.
- **No code on network errors.** Every network failure undici's `fetch` throws is a bare `TypeError: fetch failed`; the real token (`ENOTFOUND`, `ECONNRESET`, `UND_ERR_CONNECT_TIMEOUT`, …) sits on `.cause`, which `errorCodeOf` didn't read. (Probed under Node 22 — the host runs Electron's Node — not assumed.)
- **`OAUTH_TIMEOUT` was ambiguous.** A user's consent timed out with the browser never returning to the loopback. We couldn't tell "browser tab never opened" from "user abandoned Robinhood's page", nor how many times they tried.

## What

- **`errorCodeOf` → `err.code ?? err.cause?.code`** (one level, same bounded-identifier rule).
- **`broker_offline` / `broker_online`** — `pollOnce`'s catch routes through `isTransientNetworkError` (`broker/network-error.ts`: fixed code set + bare `fetch failed`). A transient failure emits `broker_offline {error_code}` **once per outage**; the first good poll after emits `broker_online {offline_ms, failed_polls}`. Anything else (mapping bug, `McpError`, HTTP error class) stays an `app_error` per occurrence — so `app_error` keeps meaning "something's wrong with the app". Status is untouched during an outage; `disconnect()` resets the state.
- **`broker_connect_started {mode: interactive|silent}`** — opens the connect funnel; the gap to `connected` / `connect_failed` is superseded/pending attempts.
- **`openExternal` failures reported** via `trackError("broker")` — a consent whose tab never opened now shows up as `app_error {broker, ENOENT|exit code}` instead of vanishing into a log.

No schema/DB change. No behaviour change beyond which events fire. All new fields are categorical/numeric — no PII.

## Tests

279/279, typecheck clean, lint identical to `main`. New: cause fallback with the real undici shapes (DNS, dual-stack `AggregateError`, one-level-only, own code wins); the classifier (sleep/wake family, not-transient cases); poll loop → one `broker_offline`, 5 consecutive still one, recovery `broker_online {failed_polls: 5}`, separate outage reports again, healthy polls silent, non-network still `app_error` every time, disconnect resets; funnel modes.

Note: the classifier is tested against constructed undici shapes rather than a live `fetch` — bun's own `fetch` throws a different error shape than Node's undici, so a live probe under `bun test` would exercise the wrong runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
