### PR TITLE
Broker: classify MCP RequestTimeout/ConnectionClosed as transient, label McpError codes

### DIFF
--- a/app/src/main/services/broker/connect.test.ts
+++ b/app/src/main/services/broker/connect.test.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { Account, OrderStatus, Portfolio, Position, Quote } from "@shared/broker";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import type { Db } from "../../db/client";
@@ -322,6 +323,19 @@ describe("BrokerService poll loop — network outages are not app errors", () =>
     expect(events(client)).toEqual(["broker_offline"]);
     expect(client.events[0].properties).toMatchObject({ error_code: "ECONNRESET" });
     // Status is untouched: the panel keeps showing cached data.
+    expect(svc.getStatus()).toBe("connected");
+  });
+
+  test("a sleep-interrupted poll (MCP RequestTimeout) is broker_offline, labelled by enum name", async () => {
+    const { svc, adapter, client } = await connectedWithAccount();
+    // The POST connected, then the machine froze mid-request → the SDK's 60 s timer.
+    adapter.pollScript = async () => {
+      throw new McpError(ErrorCode.RequestTimeout, "Request timed out");
+    };
+    await poll(svc);
+    expect(events(client)).toEqual(["broker_offline"]);
+    // The numeric MCP code becomes its enum name instead of being dropped.
+    expect(client.events[0].properties).toMatchObject({ error_code: "RequestTimeout" });
     expect(svc.getStatus()).toBe("connected");
   });
 

--- a/app/src/main/services/broker/index.ts
+++ b/app/src/main/services/broker/index.ts
@@ -1,4 +1,4 @@
-import { errorCodeOf, errorNameOf } from "@shared/analytics";
+import { errorNameOf } from "@shared/analytics";
 import type {
   Account,
   BrokerConnectionStatus,
@@ -14,7 +14,7 @@ import { analytics } from "../analytics";
 import { bus } from "../event-bus";
 import type { SettingsService } from "../settings";
 import { type BrokerAdapter, ConnectSuperseded } from "./adapter";
-import { isTransientNetworkError } from "./network-error";
+import { brokerErrorCode, isTransientNetworkError } from "./network-error";
 import { orderNotification, terminalTransition } from "./order-notify";
 
 /**
@@ -165,7 +165,7 @@ export class BrokerService {
       // The abandoned call resolves quietly rather than surfacing a spurious error.
       if (err instanceof ConnectSuperseded) return;
       this.setStatus("error");
-      const code = errorCodeOf(err);
+      const code = brokerErrorCode(err);
       analytics.track("broker_connect_failed", {
         error_name: errorNameOf(err),
         ...(code ? { error_code: code } : {}),
@@ -301,7 +301,7 @@ export class BrokerService {
     this.failedPolls++;
     if (this.offlineSince !== null) return;
     this.offlineSince = Date.now();
-    const code = errorCodeOf(err);
+    const code = brokerErrorCode(err);
     analytics.track("broker_offline", code ? { error_code: code } : {});
   }
 

--- a/app/src/main/services/broker/network-error.test.ts
+++ b/app/src/main/services/broker/network-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { McpError } from "@modelcontextprotocol/sdk/types.js";
-import { isTransientNetworkError } from "./network-error";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { brokerErrorCode, isTransientNetworkError } from "./network-error";
 
 // The shape Node's undici `fetch` throws on a network failure — a bare
 // `TypeError: fetch failed` with the code on `.cause` — as probed under Node 22 (the
@@ -33,17 +33,52 @@ describe("isTransientNetworkError", () => {
     );
   });
 
-  test("not transient: bugs, protocol errors, HTTP failures, other codes", () => {
+  test("MCP request/transport failures from a sleep-interrupted poll are transient", () => {
+    // The POST connected, then the machine froze mid-request → the SDK's 60 s timer or a
+    // detected stream close, rather than a connect-time `fetch failed`.
+    expect(
+      isTransientNetworkError(new McpError(ErrorCode.RequestTimeout, "Request timed out")),
+    ).toBe(true);
+    expect(
+      isTransientNetworkError(new McpError(ErrorCode.ConnectionClosed, "Connection closed")),
+    ).toBe(true);
+  });
+
+  test("not transient: bugs, server-side protocol errors, HTTP failures, other codes", () => {
     // A mapping bug in our own code is a TypeError too — but not `fetch failed`.
     expect(isTransientNetworkError(new TypeError("Cannot read properties of undefined"))).toBe(
       false,
     );
-    expect(isTransientNetworkError(new McpError(-32601, "Method not found"))).toBe(false);
+    // A genuine server-side JSON-RPC error is the app's problem, not the network's.
+    expect(
+      isTransientNetworkError(new McpError(ErrorCode.MethodNotFound, "Method not found")),
+    ).toBe(false);
+    expect(isTransientNetworkError(new McpError(ErrorCode.InternalError, "boom"))).toBe(false);
     expect(
       isTransientNetworkError(Object.assign(new Error("listen"), { code: "EADDRINUSE" })),
     ).toBe(false);
     expect(isTransientNetworkError(new Error("broker not connected"))).toBe(false);
     expect(isTransientNetworkError(null)).toBe(false);
     expect(isTransientNetworkError("ECONNRESET")).toBe(false);
+  });
+});
+
+describe("brokerErrorCode", () => {
+  test("maps an McpError's numeric code to its enum name (a bounded identifier)", () => {
+    expect(brokerErrorCode(new McpError(ErrorCode.RequestTimeout, "x"))).toBe("RequestTimeout");
+    expect(brokerErrorCode(new McpError(ErrorCode.ConnectionClosed, "x"))).toBe("ConnectionClosed");
+    // A server's own numeric code with no enum name → undefined (correctly dropped, not
+    // leaked as a raw number the allowlist regex would reject anyway).
+    expect(brokerErrorCode(new McpError(-32050 as ErrorCode, "custom"))).toBeUndefined();
+  });
+
+  test("falls back to errorCodeOf for the transport cases", () => {
+    expect(brokerErrorCode(withCause("ECONNRESET"))).toBe("ECONNRESET");
+    expect(brokerErrorCode(Object.assign(new Error("listen"), { code: "EADDRINUSE" }))).toBe(
+      "EADDRINUSE",
+    );
+    expect(
+      brokerErrorCode(new TypeError("fetch failed", { cause: new Error("?") })),
+    ).toBeUndefined();
   });
 });

--- a/app/src/main/services/broker/network-error.ts
+++ b/app/src/main/services/broker/network-error.ts
@@ -1,3 +1,4 @@
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { errorCodeOf } from "@shared/analytics";
 
 /** "The network is not there right now" — DNS, connect/reset/timeout, unreachable, undici's own. */
@@ -20,16 +21,41 @@ const TRANSIENT_NETWORK_CODES = new Set([
 ]);
 
 /**
+ * MCP-layer failures that mean the same thing as a network drop: the poll's request
+ * never came back. These fire one stage *later* than a connect-time `fetch failed` — the
+ * POST had already connected, then the machine froze (laptop sleep interrupting a poll),
+ * so the SDK's 60 s timer (`RequestTimeout`) fires or the stream is seen closed
+ * (`ConnectionClosed`). A genuine server-side JSON-RPC error (`InvalidParams`,
+ * `InternalError`, …) is NOT here — it stays an `app_error`.
+ */
+const TRANSIENT_MCP_CODES = new Set<number>([ErrorCode.RequestTimeout, ErrorCode.ConnectionClosed]);
+
+/**
  * Is this failure a transient network outage — what a laptop produces around
  * sleep/wake, a Wi‑Fi handoff, a VPN flap — as opposed to a bug, a protocol error, or
- * the server rejecting us? True for a code in the set above (on the error or, as undici
- * does it, on its `cause`) and for a bare `TypeError: fetch failed` whose cause we don't
- * recognize (still transport-level, never app logic; nothing in our bundle produces that
- * message). Anything else — a mapping TypeError from our code, an `McpError`, an HTTP
- * error class — is not transient and stays an `app_error`.
+ * the server rejecting us? True for a transport-level code (on the error or, as undici
+ * does it, on its `cause`), the two transient MCP codes above, and a bare
+ * `TypeError: fetch failed` whose cause we don't recognize (still transport-level, never
+ * app logic; nothing in our bundle produces that message). Anything else — a mapping
+ * TypeError from our code, a server-side `McpError`, an HTTP error class — is not
+ * transient and stays an `app_error`.
  */
 export function isTransientNetworkError(err: unknown): boolean {
+  if (err instanceof McpError && TRANSIENT_MCP_CODES.has(err.code)) return true;
   const code = errorCodeOf(err);
   if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;
   return err instanceof TypeError && err.message === "fetch failed";
+}
+
+/**
+ * The bounded telemetry code for a broker error: `errorCodeOf` (err.code / err.cause.code)
+ * for the transport cases, plus the MCP layer — an `McpError`'s `code` is a *number*
+ * (`-32001`), which the allowlist regex drops, so map it to its enum **name**
+ * (`RequestTimeout`, `ConnectionClosed`, …), a bare identifier. Unknown numeric codes
+ * (a server's own) have no enum name → undefined, correctly dropped. This keeps MCP
+ * knowledge in the broker layer; `errorCodeOf` in shared/ stays SDK-agnostic.
+ */
+export function brokerErrorCode(err: unknown): string | undefined {
+  if (err instanceof McpError) return ErrorCode[err.code];
+  return errorCodeOf(err);
 }


### PR DESCRIPTION
## Why

The v0.2.4 telemetry (its first hours) showed an `app_error {broker, McpError}` on a laptop that was asleep. Confirmed on-machine via `pmset -g log`: the Mac was in clamshell/maintenance sleep (`TCPKeepAlive=active`, on battery) at that exact minute, and **no other user's broker failed in the window** — so it's a local sleep, not Robinhood.

The mechanism: a poll whose POST had **already connected**, then the machine froze mid-request. That surfaces one stage later than the connect-time `TypeError: fetch failed` we already handle — as the MCP SDK's 60 s request timer (`RequestTimeout`) or a detected stream close (`ConnectionClosed`). Both are network-class, but `isTransientNetworkError` only looked at transport codes, so they stayed scary per-poll `app_error`s. And `McpError`'s code is numeric, so `error_code` was blank.

## What

- **`isTransientNetworkError`** also returns true for an `McpError` with code `RequestTimeout` or `ConnectionClosed` → these route to `broker_offline`/`broker_online` like their transport-code siblings. A **server-side** `McpError` (`InvalidParams`, `InternalError`, …) stays an `app_error` — that's the app's problem, not the network's.
- **`brokerErrorCode(err)`** — `errorCodeOf` plus the MCP layer: an `McpError`'s numeric code (which the allowlist regex drops) is mapped to its enum **name** (`RequestTimeout`, …), a bounded identifier. The broker's two telemetry sites (`broker_offline`, `broker_connect_failed`) use it; `errorCodeOf` in `shared/` stays SDK-agnostic (no MCP import in the renderer-facing allowlist).

~15 lines of product code, all in the broker's existing `network-error.ts`; no new event, no schema/DB change, no behaviour change beyond which bucket these land in.

## Tests

284/284, typecheck clean, lint identical to `main`. New: the two transient MCP codes classified transient; server-side codes (`MethodNotFound`, `InternalError`) still non-transient; `brokerErrorCode` enum-name mapping + unknown-numeric → undefined + transport fallback; poll-loop `RequestTimeout` → `broker_offline {error_code: "RequestTimeout"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
