### PR TITLE
Telemetry: attach build metadata to the anonymous install id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ CLAUDE.md
 # Local dev tooling and example env (not part of the public release)
 dev.sh
 .env.example
+
+/scripts/

--- a/app/src/main/services/analytics/analytics.test.ts
+++ b/app/src/main/services/analytics/analytics.test.ts
@@ -70,7 +70,7 @@ describe("AnalyticsService", () => {
     expect(svc.anonymousId).toMatch(/[0-9a-f-]{36}/);
   });
 
-  test("allowlisted event stamps super-props + the anonymous flag", () => {
+  test("allowlisted event stamps super-props + person properties", () => {
     const fake = new FakeClient();
     const svc = makeService(new SettingsService(memDb()), fake);
     svc.track("agent_created", { template: "dca", harness: "claude", approval_mode: "auto" });
@@ -83,9 +83,25 @@ describe("AnalyticsService", () => {
       approval_mode: "auto",
       platform: process.platform,
       arch: process.arch,
-      $process_person_profile: false,
     });
     expect(e.properties?.app_version).toBeDefined();
+    // Person profiles must be created: the personless flag would suppress them.
+    expect(e.properties).not.toHaveProperty("$process_person_profile");
+    // $set/$set_once are stamped AFTER Zod validation, so they are the one channel
+    // that bypasses the allowlist. Pin their key sets exactly: a subset match would let
+    // a newly added super-prop reach PostHog without anyone reviewing it.
+    const set = e.properties?.$set as Record<string, unknown>;
+    expect(Object.keys(set).sort()).toEqual(["app_version", "arch", "platform"]);
+    expect(set).toMatchObject({
+      app_version: e.properties?.app_version,
+      platform: process.platform,
+      arch: process.arch,
+    });
+    // The install's origin via $set_once, which never overwrites.
+    const setOnce = e.properties?.$set_once as Record<string, unknown>;
+    expect(Object.keys(setOnce).sort()).toEqual(["first_seen_at", "first_seen_version"]);
+    expect(setOnce.first_seen_version).toBe(e.properties?.app_version);
+    expect(String(setOnce.first_seen_at)).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
   test("an event with an extra prop is dropped whole (no PII leak)", () => {

--- a/app/src/main/services/analytics/index.ts
+++ b/app/src/main/services/analytics/index.ts
@@ -54,8 +54,10 @@ const REPORTABLE_SETTING_KEYS = [
  *
  * Privacy is structural: `track()` validates every payload against the strict
  * `TELEMETRY_EVENTS` allowlist and drops anything that doesn't parse. The distinct
- * id is a random per-install UUID (never a machine/user identifier); events set
- * `$process_person_profile: false` so PostHog keeps them anonymous.
+ * id is a random per-install UUID (never a machine/user identifier). Events create a
+ * PostHog person profile keyed by that anonymous id, carrying only the build metadata
+ * we already send as event props (version/platform/arch) — never a machine or user
+ * identifier. The profile is what makes Persons, cohorts and lifecycle work.
  *
  * Disabled ⇔ `client` is null (no key / dev / not started) **or** the user opted out
  * (`enabled`), checked live at capture time via `settings:changed`.
@@ -65,6 +67,7 @@ export class AnalyticsService {
   private enabled = false;
   private distinctId = "";
   private superProps: Record<string, unknown> = {};
+  private personProps: Record<string, unknown> = {};
   private lastSettings: AppSettings | null = null;
   private unsubs: Array<() => void> = [];
   private started = false;
@@ -108,6 +111,17 @@ export class AnalyticsService {
       platform: process.platform,
       arch: process.arch,
     };
+    // Person-profile properties: the same values we already send as event props, no
+    // new data. `$set` tracks the install's current build; `$set_once` records where
+    // it started — only the first event ever to land for this id sets those, so they
+    // survive upgrades and give "new vs existing install" a real anchor.
+    this.personProps = {
+      $set: { ...this.superProps },
+      $set_once: {
+        first_seen_version: this.superProps.app_version,
+        first_seen_at: new Date().toISOString(),
+      },
+    };
     this.unsubs.push(bus.onEvent("settings:changed", (next) => this.onSettingsChanged(next)));
     this.unsubs.push(bus.onEvent("gui:present", () => this.track("app_opened")));
   }
@@ -120,7 +134,7 @@ export class AnalyticsService {
   /**
    * Capture a telemetry event. Validated against the allowlist; a payload with an
    * unknown/extra prop (or an unknown event) is **dropped whole** — never partially
-   * sent. Super-props + the anonymous flag are stamped here, not by callers.
+   * sent. Super-props + person properties are stamped here, not by callers.
    */
   track<E extends TelemetryEvent>(event: E, props?: TelemetryProps<E>): void {
     if (!this.client || !this.enabled) return;
@@ -141,7 +155,7 @@ export class AnalyticsService {
         properties: {
           ...(parsed.data as Record<string, unknown>),
           ...this.superProps,
-          $process_person_profile: false,
+          ...this.personProps,
         },
       });
     } catch (err) {


### PR DESCRIPTION
Events no longer set `$process_person_profile: false`. They now additionally carry the app version, platform and architecture — the same values already sent as event properties — under `$set`, plus `$set_once` fields recording the version and timestamp first seen for an install, which later events do not overwrite.

No additional data is collected. The distinct id remains a random per-install UUID that is never a machine or user identifier, geoip stays disabled, and the fail-closed `TELEMETRY_EVENTS` allowlist is unchanged.

These properties are stamped after schema validation, so the tests pin their key sets exactly — a newly added property fails the suite rather than reaching the wire unreviewed.

Also gitignores a top-level `scripts/` directory for local tooling. The rule is root-anchored so it does not cover `app/scripts/`, which is tracked build tooling that packaging depends on.

## Verification

- `bun test` — 284 pass, 0 fail
- `bun run typecheck` — clean
- `bunx @biomejs/biome check app/src/main/services/analytics/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)