### PR TITLE
Make broker errors diagnosable: error codes, dependency frames, durable log

### DIFF
--- a/app/bunfig.toml
+++ b/app/bunfig.toml
@@ -1,0 +1,5 @@
+[test]
+# Bun reads bunfig.toml from the cwd and does NOT search upward, so the root config
+# alone leaves `bun test` run from this directory — the natural place, since every test
+# lives under app/src — writing into the user's real ~/.opentrade. See ../test-setup.ts.
+preload = ["../test-setup.ts"]

--- a/app/src/main/host/index.ts
+++ b/app/src/main/host/index.ts
@@ -18,6 +18,7 @@ import { analytics } from "../services/analytics";
 import { ApprovalService } from "../services/approvals";
 import { AuditLog } from "../services/audit";
 import { BrokerService } from "../services/broker";
+import { brokerErrorCode } from "../services/broker/network-error";
 import { RobinhoodAdapter } from "../services/broker/robinhood/client";
 import { bus } from "../services/event-bus";
 import { registerHarness } from "../services/harness";
@@ -55,7 +56,7 @@ function openExternal(url: string): void {
   execFile(cmd, [url], (err) => {
     if (!err) return;
     hostLog.error("openExternal failed", String(err));
-    analytics.trackError("broker", err, "caught");
+    analytics.trackError("broker", err, "caught", brokerErrorCode(err));
   });
 }
 

--- a/app/src/main/services/analytics/analytics.test.ts
+++ b/app/src/main/services/analytics/analytics.test.ts
@@ -227,6 +227,39 @@ describe("AnalyticsService", () => {
     expect(fake.events[0].properties).not.toHaveProperty("frames");
     expect(JSON.stringify(fake.events[0].properties)).not.toContain("127.0.0.1");
   });
+
+  test("trackError takes a codeOverride for a code errorCodeOf cannot see", () => {
+    const fake = new FakeClient();
+    const svc = makeService(new SettingsService(memDb()), fake);
+    // An McpError's `code` is numeric (-32603), which the allowlist drops — so the
+    // broker resolves it to its enum name and passes that in. Without the override
+    // these arrive as a bare class name with nothing saying which failure it was.
+    const err = Object.assign(new Error("MCP error -32603: Internal error"), { code: -32603 });
+    svc.trackError("broker", err, "caught", "InternalError");
+    expect(fake.events[0].properties).toMatchObject({
+      subsystem: "broker",
+      error_name: "Error",
+      error_code: "InternalError",
+    });
+  });
+
+  test("trackError ignores a codeOverride that isn't allowlist-shaped", () => {
+    const fake = new FakeClient();
+    const svc = makeService(new SettingsService(memDb()), fake);
+    // An override is re-gated, so a caller can never widen the field — and, since an
+    // invalid prop drops the whole event, can never cost us the app_error either.
+    svc.trackError("broker", new Error("x"), "caught", "not a code /Users/alice");
+    expect(fake.events).toHaveLength(1);
+    expect(fake.events[0].properties).not.toHaveProperty("error_code");
+  });
+
+  test("trackError prefers a real err.code over an unusable override", () => {
+    const fake = new FakeClient();
+    const svc = makeService(new SettingsService(memDb()), fake);
+    const err = Object.assign(new Error("x"), { code: "ECONNRESET" });
+    svc.trackError("broker", err, "caught", undefined);
+    expect(fake.events[0].properties).toMatchObject({ error_code: "ECONNRESET" });
+  });
 });
 
 describe("analytics allowlist + normalizers", () => {
@@ -374,7 +407,7 @@ describe("analytics allowlist + normalizers", () => {
     ).toBe(true);
   });
 
-  test("sanitizeStack keeps bundle frames only, drops internals + node_modules", () => {
+  test("sanitizeStack keeps bundle + dependency frames, drops node internals", () => {
     const err = new Error("boom");
     err.stack = [
       "Error: boom",
@@ -383,7 +416,112 @@ describe("analytics allowlist + normalizers", () => {
       "    at ws (/Users/a/node_modules/ws/lib/index.js:10:2)",
       "    at main (/Users/a/out/main/index.js:5:9)",
     ].join("\n");
-    expect(sanitizeStack(err)).toEqual(["host.js:41231:17", "index.js:5:9"]);
+    expect(sanitizeStack(err)).toEqual(["host.js:41231:17", "ws/index.js:10:2", "index.js:5:9"]);
+  });
+
+  test("sanitizeStack labels a dependency frame with its package, scope included", () => {
+    // The shape that made every backend app_error frameless: the whole stack sits in
+    // the MCP SDK, so dropping node_modules frames left nothing at all.
+    const err = new Error("boom");
+    err.stack = [
+      "McpError: MCP error -32603",
+      "    at Client._onresponse (/Applications/OpenTrade.app/Contents/Resources/app.asar/node_modules/@modelcontextprotocol/sdk/dist/cjs/shared/protocol.js:301:31)",
+      "    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)",
+    ].join("\n");
+    expect(sanitizeStack(err)).toEqual(["@modelcontextprotocol/sdk/protocol.js:301:31"]);
+  });
+
+  test("sanitizeStack resolves a nested dependency to the package that owns the frame", () => {
+    const err = new Error("boom");
+    err.stack = [
+      "Error: boom",
+      "    at f (/Users/a/node_modules/.bun/ws@8/node_modules/ws/lib/sender.js:7:3)",
+    ].join("\n");
+    expect(sanitizeStack(err)).toEqual(["ws/sender.js:7:3"]);
+  });
+
+  test("sanitizeStack frames carry no directory, and stay inside the allowlist shape", () => {
+    // The privacy guarantee: whatever the user's install path, only a package name and
+    // a basename survive — so a home directory can never ride along in `frames`.
+    const err = new Error("boom");
+    err.stack = [
+      "Error: boom",
+      "    at a (/Users/somebody/secret-dir/out/main/host.js:1:2)",
+      "    at b (/Users/somebody/secret-dir/node_modules/@scope/pkg/deep/nested/file.js:3:4)",
+    ].join("\n");
+    const frames = sanitizeStack(err);
+    expect(frames).toEqual(["host.js:1:2", "@scope/pkg/file.js:3:4"]);
+    for (const f of frames) expect(f).not.toContain("somebody");
+    // Must survive the strict allowlist — a frame that fails it drops the whole event.
+    expect(
+      TELEMETRY_EVENTS.app_error.safeParse({
+        subsystem: "broker",
+        error_name: "McpError",
+        frames,
+      }).success,
+    ).toBe(true);
+  });
+
+  test("sanitizeStack does not treat a directory merely ending in node_modules as one", () => {
+    // `indexOf("node_modules/")` without a path boundary would publish the user's own
+    // next directory as if it were a package name.
+    const err = new Error("boom");
+    err.stack = [
+      "Error: boom",
+      "    at f (/Users/alice/my-node_modules/Acme-Client-Trades/lib/x.js:1:2)",
+    ].join("\n");
+    const frames = sanitizeStack(err);
+    expect(frames).toEqual(["x.js:1:2"]);
+    expect(JSON.stringify(frames)).not.toContain("Acme");
+  });
+
+  test("sanitizeStack ignores the message line, which is free text", () => {
+    // The `<Class>: <message>` line is server-influenceable (an McpError's message), so
+    // mining it for a `file.js:line` would turn message text into telemetry.
+    const err = new Error("boom");
+    err.stack = [
+      "Error: request to /srv/node_modules/AAPL-strategy/buy-500-shares.js:42 failed",
+      "    at g (/app/out/main/main.js:1:1)",
+    ].join("\n");
+    const frames = sanitizeStack(err);
+    expect(frames).toEqual(["main.js:1:1"]);
+    expect(JSON.stringify(frames)).not.toContain("AAPL");
+  });
+
+  test("sanitizeStack rejects traversal segments as package names", () => {
+    const err = new Error("boom");
+    err.stack = ["Error: boom", "    at f (/a/node_modules/../../../Users/alice/x.js:9:9)"].join(
+      "\n",
+    );
+    expect(sanitizeStack(err)).toEqual(["x.js:9:9"]);
+  });
+
+  test("sanitizeStack labels dependency frames on Windows paths too", () => {
+    const err = new Error("boom");
+    err.stack = ["Error: boom", "    at f (C:\\p\\node_modules\\ws\\lib\\index.js:10:2)"].join(
+      "\n",
+    );
+    expect(sanitizeStack(err)).toEqual(["ws/index.js:10:2"]);
+  });
+
+  test("one over-long frame is shed, never allowed to drop the whole event", () => {
+    // frames are `.max(128)`; a frame past it fails validation, and an invalid prop
+    // drops the entire app_error — so the length has to be enforced while building.
+    const err = new Error("boom");
+    err.stack = [
+      "Error: boom",
+      `    at f (/app/out/${"a".repeat(200)}.js:1:1)`,
+      "    at g (/app/out/main.js:2:2)",
+    ].join("\n");
+    const frames = sanitizeStack(err);
+    expect(frames).toEqual(["main.js:2:2"]);
+    expect(
+      TELEMETRY_EVENTS.app_error.safeParse({
+        subsystem: "broker",
+        error_name: "Error",
+        frames,
+      }).success,
+    ).toBe(true);
   });
 
   test("sanitizeStack caps at 10 frames", () => {

--- a/app/src/main/services/analytics/index.ts
+++ b/app/src/main/services/analytics/index.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
+  asErrorCode,
   type ErrorSource,
   type ErrorSubsystem,
   errorCodeOf,
@@ -172,10 +173,21 @@ export class AnalyticsService {
    * The code matters most for async Node system errors: their stack is entirely
    * `node:internal` frames (so `frames` is empty) and their class is plain `Error`,
    * leaving `error_code` as the only thing that says what actually went wrong.
+   *
+   * `codeOverride` is for a subsystem that knows the code by a route `errorCodeOf`
+   * cannot take — the broker's `brokerErrorCode`, which resolves an `McpError`'s
+   * *numeric* code (`-32001`) to its enum name. Without it those errors reach us as a
+   * bare class name with no code at all. It is re-gated through `asErrorCode`, so an
+   * override can only ever narrow to what the allowlist already accepts.
    */
-  trackError(subsystem: ErrorSubsystem, err: unknown, source: ErrorSource = "caught"): void {
+  trackError(
+    subsystem: ErrorSubsystem,
+    err: unknown,
+    source: ErrorSource = "caught",
+    codeOverride?: string,
+  ): void {
     const frames = sanitizeStack(err);
-    const code = errorCodeOf(err);
+    const code = asErrorCode(codeOverride) ?? errorCodeOf(err);
     this.track("app_error", {
       subsystem,
       error_name: errorNameOf(err),

--- a/app/src/main/services/broker/connect.test.ts
+++ b/app/src/main/services/broker/connect.test.ts
@@ -385,6 +385,37 @@ describe("BrokerService poll loop — network outages are not app errors", () =>
     });
   });
 
+  test("an unprintable thrown value still reports — logging must not eat the telemetry", async () => {
+    const { svc, adapter, client } = await connectedWithAccount();
+    // A null-prototype object makes `String()` throw. The failure description is built
+    // first in the catch, so an unguarded throw there would skip trackError entirely and
+    // turn a handled poll failure into an unhandled rejection.
+    adapter.pollScript = async () => {
+      throw Object.create(null);
+    };
+    await poll(svc);
+    expect(events(client)).toEqual(["app_error"]);
+    expect(client.events[0].properties).toMatchObject({ subsystem: "broker", source: "caught" });
+  });
+
+  test("a server-side McpError app_error is labelled by enum name, not left bare", async () => {
+    const { svc, adapter, client } = await connectedWithAccount();
+    // Not one of the transient MCP codes, so it stays an app_error — the bucket that in
+    // production arrived as `McpError` with no code at all, because an McpError's `code`
+    // is numeric (-32603) and the allowlist drops numbers. The broker resolves it.
+    adapter.pollScript = async () => {
+      throw new McpError(ErrorCode.InternalError, "Internal error");
+    };
+    await poll(svc);
+    expect(events(client)).toEqual(["app_error"]);
+    expect(client.events[0].properties).toMatchObject({
+      subsystem: "broker",
+      error_name: "McpError",
+      error_code: "InternalError",
+      source: "caught",
+    });
+  });
+
   test("disconnect closes the books: no broker_online spanning a deliberate disconnect", async () => {
     const { svc, adapter, client } = await connectedWithAccount();
     adapter.pollScript = async () => {

--- a/app/src/main/services/broker/index.ts
+++ b/app/src/main/services/broker/index.ts
@@ -10,6 +10,7 @@ import type {
 import { eq } from "drizzle-orm";
 import type { Db } from "../../db/client";
 import { brokerCache } from "../../db/schema";
+import { hostLog } from "../../host/log";
 import { analytics } from "../analytics";
 import { bus } from "../event-bus";
 import type { SettingsService } from "../settings";
@@ -29,6 +30,43 @@ const FULL_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
 // Robinhood's MCP rate limits are generous, so we poll often for a near-live
 // panel. The cadence (focused-during-market-hours vs otherwise) is user-tunable
 // in Settings; see SettingsService.pollInterval{Focused,Blurred}Ms.
+
+/**
+ * A broker failure rendered for the **local** host log: class, machine code, message,
+ * and the `cause` chain that carries the real reason for a wrapped `fetch failed`.
+ *
+ * `host.log` never leaves the machine — telemetry sends only the allowlisted class,
+ * code and frames — so this is the one place the actual message survives, and the thing
+ * that makes a poll failure diagnosable after the fact instead of only countable.
+ * Bounded in depth and length: the log is append-only and never rotated, so a verbose
+ * MCP payload must not be able to bloat it.
+ */
+function describeError(err: unknown): string {
+  // Every read is guarded: this runs *first* in pollOnce's catch, so a throw here would
+  // skip the telemetry below and convert a handled poll failure into an unhandled
+  // rejection. A null-prototype object makes `String()` throw, and a `message`/`code`
+  // getter can throw anything at all.
+  try {
+    const parts: string[] = [];
+    let cur: unknown = err;
+    for (let depth = 0; cur != null && depth < 3; depth++) {
+      const e = cur as { message?: unknown; code?: unknown; cause?: unknown };
+      let part: string;
+      try {
+        const code = e.code === undefined ? "" : ` (code=${String(e.code)})`;
+        const msg = typeof e.message === "string" ? e.message : String(cur);
+        part = `${errorNameOf(cur)}${code}: ${msg}`;
+      } catch {
+        part = "<unprintable>";
+      }
+      parts.push(part);
+      cur = e.cause;
+    }
+    return parts.join(" ← ").slice(0, 500);
+  } catch {
+    return "<unprintable>";
+  }
+}
 
 /** True during NY regular + extended hours on a weekday (holidays not handled). */
 function marketActive(now = new Date()): boolean {
@@ -277,18 +315,59 @@ export class BrokerService {
       updated.push("agentic_orders");
 
       bus.emitEvent("broker:updated", { keys: updated });
+      this.notePollRecovered();
       this.noteOnline();
     } catch (err) {
-      console.error("[broker] poll failed", err);
+      // `console.error` here went to the detached host's stdout, i.e. nowhere: the log
+      // file had no record of a poll failure at all. hostLog is the only durable sink.
+      this.logPollFailure(describeError(err));
       // A poll that was in flight when disconnect() ran fails by design (its client was
       // closed under it) — nothing to report, and it must not reopen outage tracking.
       if (this.status !== "connected") return;
       // Network outage (laptop sleep/wake, Wi‑Fi blip) → broker_offline; else app_error.
       if (isTransientNetworkError(err)) this.noteOffline(err);
-      else analytics.trackError("broker", err, "caught");
+      else analytics.trackError("broker", err, "caught", brokerErrorCode(err));
     } finally {
       this.polling = false;
     }
+  }
+
+  // ---- poll-failure logging (deduped) ----
+
+  /** The last failure written to host.log, and how many identical ones followed it. */
+  private lastFailureLog: string | null = null;
+  private suppressedFailures = 0;
+
+  /**
+   * Log a poll failure once per *run* of identical failures. `host.log` is append-only
+   * and never rotated, and the poll runs every 5–10 s, so logging every failure would
+   * let one persistent fault (a revoked grant, a laptop offline overnight) grow the file
+   * unboundedly — megabytes a day. A change in the failure is always logged; a repeat is
+   * counted and reported once on recovery. This mirrors the dedup `broker_offline`
+   * already applies to telemetry.
+   */
+  private logPollFailure(description: string): void {
+    if (description === this.lastFailureLog) {
+      this.suppressedFailures++;
+      return;
+    }
+    if (this.lastFailureLog !== null) this.flushSuppressedFailures();
+    this.lastFailureLog = description;
+    hostLog.warn(`broker poll failed: ${description}`);
+  }
+
+  /** First success after failures: close the books so the next failure logs again. */
+  private notePollRecovered(): void {
+    if (this.lastFailureLog === null) return;
+    this.flushSuppressedFailures();
+    this.lastFailureLog = null;
+  }
+
+  private flushSuppressedFailures(): void {
+    if (this.suppressedFailures > 0) {
+      hostLog.info(`broker poll: ${this.suppressedFailures} further identical failure(s)`);
+    }
+    this.suppressedFailures = 0;
   }
 
   // ---- outage tracking (poll loop) ----

--- a/app/src/shared/analytics.ts
+++ b/app/src/shared/analytics.ts
@@ -41,10 +41,16 @@ const errorCode = z.string().regex(/^[A-Za-z0-9_]{1,48}$/);
 const version = z.string().regex(/^\d+\.\d+\.\d+(?:-[\w.]+)?$/);
 
 /**
- * A sanitized stack frame: `<bundle>.js:line[:col]` — bundle basename only, so it
- * points at our code without carrying a directory (no user path) or a message.
+ * A sanitized stack frame: `<bundle>.js:line[:col]` for our own bundles, or
+ * `<pkg>/<file>.js:line[:col]` for a frame inside a dependency. Never more than a
+ * package name plus a basename, so it points at code without carrying a directory
+ * (no user path) or a message.
  */
-const stackFrame = z.string().regex(/^[\w.-]+\.js:\d+(?::\d+)?$/);
+const MAX_STACK_FRAME = 128;
+const stackFrame = z
+  .string()
+  .max(MAX_STACK_FRAME)
+  .regex(/^(?:(?:@[\w.-]+\/)?[\w.-]+\/)?[\w.-]+\.js:\d+(?::\d+)?$/);
 const frames = z.array(stackFrame).max(10);
 
 const assetType = z.enum(["equity", "option", "other"]);
@@ -284,10 +290,19 @@ export function templateOf(template: string | null | undefined): z.infer<typeof 
 }
 
 /**
- * Extract a sanitized stack fingerprint from an error: `<bundle>.js:line[:col]`
- * frames pointing into our own bundles, node internals / node_modules dropped, at
- * most 10. Taking only the file **basename** structurally strips any directory, so
- * no user path or message can ride along.
+ * Extract a sanitized stack fingerprint from an error: at most 10 frames, each
+ * `<bundle>.js:line[:col]` for our own bundles or `<pkg>/<file>.js:line[:col]` for a
+ * frame inside a dependency. Node internals are dropped — their line numbers move with
+ * the runtime, and the error's class plus `error_code` already say what happened.
+ *
+ * Dependency frames are deliberately **kept**: host-process errors are overwhelmingly
+ * thrown inside one (the broker's inside `@modelcontextprotocol/sdk`, the updater's
+ * inside `electron-updater`), so dropping them left every backend `app_error` with no
+ * stack at all, while renderer errors — thrown in our own bundle — kept theirs.
+ *
+ * Taking only the file **basename**, plus for a dependency the package name resolved
+ * from after the last `node_modules/`, structurally strips any directory, so no user
+ * path or message can ride along.
  */
 export function sanitizeStack(err: unknown): string[] {
   const stack = err instanceof Error && typeof err.stack === "string" ? err.stack : "";
@@ -295,13 +310,49 @@ export function sanitizeStack(err: unknown): string[] {
   const out: string[] = [];
   const re = /([\w.-]+\.js):(\d+)(?::(\d+))?/;
   for (const line of stack.split("\n")) {
-    if (/node:internal|node_modules/.test(line)) continue;
+    // Only real frames. The first line of a stack is `<Class>: <message>` — free text,
+    // and on an `McpError` server-influenced — so mining it for a `file.js:line` would
+    // turn a message into telemetry. It also bounds the work `re` does per line.
+    if (!/^\s+at /.test(line)) continue;
+    if (/node:internal/.test(line)) continue;
     const m = line.match(re);
     if (!m) continue;
-    out.push(m[3] ? `${m[1]}:${m[2]}:${m[3]}` : `${m[1]}:${m[2]}`);
+    const at = m[3] ? `${m[1]}:${m[2]}:${m[3]}` : `${m[1]}:${m[2]}`;
+    const pkg = packageOf(line);
+    // Length is enforced here, not only in the schema: a frame over the cap would fail
+    // validation and drop the **whole** event, losing the other nine good frames with
+    // it. Degrade instead — shed the package prefix, then the frame itself.
+    const frame = pkg ? `${pkg}/${at}` : at;
+    if (frame.length <= MAX_STACK_FRAME) out.push(frame);
+    else if (at.length <= MAX_STACK_FRAME) out.push(at);
+    else continue;
     if (out.length >= 10) break;
   }
   return out;
+}
+
+/**
+ * The npm package a stack line points into — `name` or `@scope/name` — read from after
+ * the **last** `node_modules/`, so a nested dependency resolves to the package that
+ * actually owns the frame. Null when the line is not inside a dependency, or when the
+ * segment does not look like a package name; the frame then degrades to its bare
+ * basename rather than carrying through anything unexpected.
+ */
+function packageOf(line: string): string | null {
+  // The marker must be a whole path segment. A bare `indexOf("node_modules/")` also
+  // fires on a *user* directory merely ending in it (`~/my-node_modules/Acme-Client/`),
+  // which would publish that directory's name as if it were a package. Both separators
+  // are accepted so the labelling works on Windows too.
+  let after = -1;
+  for (const m of line.matchAll(/(?:^|[/\\(\s])node_modules[/\\]/g)) {
+    after = (m.index ?? 0) + m[0].length;
+  }
+  if (after === -1) return null;
+  const seg = line.slice(after).split(/[/\\]/);
+  const name = seg[0]?.startsWith("@") ? `${seg[0]}/${seg[1] ?? ""}` : (seg[0] ?? "");
+  if (!/^(?:@[\w.-]+\/)?[\w.-]+$/.test(name)) return null;
+  // `.`/`..` satisfy the charset but are traversal, not a package.
+  return /(?:^|\/)\.\.?$/.test(name) ? null : name;
 }
 
 /** The constructor name of a thrown value, normalized to the `error_name` shape. */
@@ -333,6 +384,17 @@ export function errorNameOf(err: unknown): string {
 export function errorCodeOf(err: unknown): string | undefined {
   const codeOn = (v: unknown) =>
     typeof v === "object" && v !== null ? (v as { code?: unknown }).code : undefined;
-  const code = codeOn(err) ?? codeOn((err as { cause?: unknown } | null)?.cause);
-  return errorCode.safeParse(code).success ? (code as string) : undefined;
+  return asErrorCode(codeOn(err) ?? codeOn((err as { cause?: unknown } | null)?.cause));
+}
+
+/**
+ * A value as an `error_code`, or undefined — nothing is coerced or truncated into one.
+ * The single gate for the field, used both by `errorCodeOf`'s discovery and by a caller
+ * that already knows the code by another route (see `brokerErrorCode`, which resolves an
+ * `McpError`'s *numeric* code to its enum name). Keeping the check here means a
+ * caller-supplied code can never widen what the allowlist accepts — and, since a prop
+ * that fails validation drops the **whole** event, can never cost us an `app_error`.
+ */
+export function asErrorCode(value: unknown): string | undefined {
+  return errorCode.safeParse(value).success ? (value as string) : undefined;
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+[test]
+# Points OPENTRADE_HOME at a throwaway dir before any module captures it, so the suite
+# cannot write into the user's real ~/.opentrade. See test-setup.ts.
+preload = ["./test-setup.ts"]

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,0 +1,29 @@
+/**
+ * Test bootstrap: give the suite its own OPENTRADE_HOME.
+ *
+ * `OPENTRADE_HOME` defaults to `~/.opentrade` — the *production* home — and is captured
+ * at module load (`db/client.ts`), so it has to be set before anything imports it. That
+ * is why this runs as a bunfig `[test] preload` rather than a `beforeAll`.
+ *
+ * Without it, any module under test that logs through `hostLog` appends to the real
+ * `~/.opentrade/host.log`: a `bun test` run leaves fixture lines ("host crash" recovery,
+ * declined gate prompts, dropped analytics events) in the log a user or maintainer reads
+ * to diagnose a live incident, indistinguishable from things the app actually did.
+ *
+ * Set unconditionally: an inherited OPENTRADE_HOME (a dev instance, a `dev.sh` shell)
+ * would otherwise point the suite at that instance's real state.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const home = mkdtempSync(join(tmpdir(), "opentrade-test-"));
+process.env.OPENTRADE_HOME = home;
+
+process.on("exit", () => {
+  try {
+    rmSync(home, { recursive: true, force: true });
+  } catch {
+    // best-effort: a leftover temp dir is harmless, and throwing here would fail the run
+  }
+});


### PR DESCRIPTION
Broker `app_error` events carried neither a machine code nor a stack, leaving the error class name as the only signal — enough to count failures, not enough to say what any of them were. Four independent causes, fixed together.

## What changed

**Error codes now land.** `trackError` takes an optional `codeOverride`, and both broker call sites pass `brokerErrorCode(err)`. An `McpError`'s `code` is a *number* (`-32603`) and `error_code` accepts bare identifiers only, so it was always dropped — even though `brokerErrorCode` already resolved it to its enum name for `broker_offline` and `broker_connect_failed`. Overrides are re-gated through the new `asErrorCode`, the single place deciding what qualifies as a code, so a caller can only narrow to what the allowlist already accepts and cannot drop an event by supplying an invalid one.

**Stack frames survive.** `sanitizeStack` keeps frames inside dependencies as `<pkg>/<file>.js:line`. Host-process errors are nearly always thrown *inside* a dependency (`@modelcontextprotocol/sdk`, `electron-updater`), so the `node_modules` filter removed every frame they had, while renderer errors — thrown in our own bundle — kept theirs. Three rules keep the "no path, no free text" guarantee intact now that these frames survive:

- Only `^\s+at ` lines are scanned. The first stack line is `<Class>: <message>` — free text, and server-influenced on an `McpError` — so a message quoting a path under `node_modules/` would otherwise have its directory and filename harvested into a frame. The old filter discarded that line as a side effect; it is now excluded deliberately.
- The `node_modules` marker is anchored to a path boundary. As a bare substring it also fires on a *user* directory merely ending in it (`~/my-node_modules/Acme-Client/x.js`), publishing that directory's name as though it were a package. Both separators are accepted, so labelling works on Windows; `.`/`..` are rejected.
- The 128-char cap is enforced while frames are built, not only in the schema — a frame past it fails validation, and an invalid prop drops the *whole* event.

**Poll failures reach the log.** They used `console.error`, which in the detached daemon goes nowhere, so the log held no record of a broker failure at all. Now `hostLog.warn` with class, code, message and `cause` chain. `describeError` guards every read: it runs first in the catch, so a throw there skipped the telemetry below and turned a handled failure into an unhandled rejection. Logging is deduped per run of identical failures — the log is append-only and never rotated and the poll runs every 5–10s, so logging every failure let one persistent fault grow it by megabytes a day.

**Tests stop writing to the real home.** `bunfig.toml` preloads `test-setup.ts`, pointing `OPENTRADE_HOME` at a per-run temp dir. It is captured at module load, so a `beforeAll` is too late. The config exists in both the repo root and `app/` — Bun reads it from the cwd and does not search upward, and every test lives under `app/src`.

## Scope

This makes broker errors diagnosable; it does not fix them. The remaining `McpError` bucket stays unattributed until builds carrying this are in the field and events come back with codes attached.

## Testing

297 pass / 0 fail (13 new). `typecheck` clean, production `build` succeeds, `biome check` clean. New tests cover the override gate, dependency-frame shapes (scoped, nested, Windows), both path-leak shapes, traversal segments, the over-long frame, and an unprintable thrown value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)