### PR TITLE
Add a macOS menu bar item so agents stay visible after the window closes

### DIFF
--- a/app/src/main/db/ddl.ts
+++ b/app/src/main/db/ddl.ts
@@ -23,6 +23,7 @@ export const SCHEMA_DDL = `
       status TEXT NOT NULL DEFAULT 'idle',
       headless_turns_used INTEGER NOT NULL DEFAULT 0,
       turn_limit_enabled INTEGER NOT NULL DEFAULT 1,
+      last_turn_at INTEGER,
       created_at INTEGER NOT NULL,
       archived_at INTEGER
     );
@@ -88,4 +89,12 @@ export const SCHEMA_DDL = `
       fired_at INTEGER NOT NULL
     );
     CREATE INDEX IF NOT EXISTS wakes_agent_fired ON wakes (agent_id, fired_at);
+    CREATE TABLE IF NOT EXISTS recent_notifications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      kind TEXT NOT NULL,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      agent_id TEXT,
+      at INTEGER NOT NULL
+    );
 `;

--- a/app/src/main/db/migrate.test.ts
+++ b/app/src/main/db/migrate.test.ts
@@ -36,6 +36,21 @@ describe("db migrations", () => {
     expect(columns(db, "agents")).toContain("turn_limit_enabled");
     expect(columns(db, "agents")).toContain("harness");
     expect(columns(db, "wakes")).toContain("source_id"); // v4
+    expect(columns(db, "agents")).toContain("last_turn_at"); // v5
+    // Whole new tables ride the DDL — no migration, no version bump (§6.3).
+    expect(columns(db, "recent_notifications")).toContain("at");
+  });
+
+  test("an existing DB picks up a whole new table from the DDL alone", () => {
+    const db = new Database(":memory:");
+    const m = wrap(db);
+    // A shipped DB predating recent_notifications: baseline agents, no version stamp.
+    db.exec(BASELINE_AGENTS);
+    expect(userVersion(m)).toBe(0);
+    db.exec(SCHEMA_DDL); // boot order: DDL first, then migrate
+    migrate(m, { fresh: false });
+    expect(columns(db, "recent_notifications")).toContain("kind");
+    expect(db.query("SELECT * FROM recent_notifications").all()).toEqual([]);
   });
 
   test("a v0.1.x production DB (user_version 0) migrates in place, preserving rows", () => {
@@ -57,6 +72,7 @@ describe("db migrations", () => {
     expect(row.headless_turns_used).toBe(0); // new columns arrived with their defaults
     expect(row.turn_limit_enabled).toBe(1);
     expect(row.harness).toBe("claude"); // v3: pre-harness agents default to claude
+    expect(row.last_turn_at).toBe(null); // v5: never spoke since the column shipped
   });
 
   test("replaying against an already-current table is a no-op (idempotent steps)", () => {

--- a/app/src/main/db/migrate.ts
+++ b/app/src/main/db/migrate.ts
@@ -34,7 +34,7 @@ export interface MigrationDb {
 }
 
 /** Bump on every schema change, with a matching entry in MIGRATIONS. */
-export const SCHEMA_VERSION = 4;
+export const SCHEMA_VERSION = 5;
 
 const MIGRATIONS: Record<number, (db: MigrationDb) => void> = {
   // v2 — headless turn limit: per-agent unattended-turn counter + on/off toggle.
@@ -51,6 +51,12 @@ const MIGRATIONS: Record<number, (db: MigrationDb) => void> = {
   // Nullable: pre-v4 wakes read NULL rather than a bogus id.
   4: (db) => {
     addColumnIfMissing(db, "wakes", "source_id", "TEXT");
+  },
+  // v5 — when the agent last spoke, feeding the menu bar item's "last active"
+  // (§12.6). Nullable: existing agents read NULL until their next turn, and fall
+  // back to their wake/audit history in the meantime.
+  5: (db) => {
+    addColumnIfMissing(db, "agents", "last_turn_at", "INTEGER");
   },
 };
 

--- a/app/src/main/db/schema.ts
+++ b/app/src/main/db/schema.ts
@@ -15,6 +15,10 @@ export const agents = sqliteTable("agents", {
   headlessTurnsUsed: integer("headless_turns_used").notNull().default(0),
   /** Whether the global headless turn limit applies to this agent. */
   turnLimitEnabled: integer("turn_limit_enabled", { mode: "boolean" }).notNull().default(true),
+  /** Last time the AGENT spoke — its turn ended, or it asked for input (§6.7 status
+   *  hook). Feeds `Agent.lastActiveAt` (§12.6). Persisted rather than held in memory so
+   *  it survives a host restart, which every app update forces. Null = never. */
+  lastTurnAt: integer("last_turn_at"),
   createdAt: integer("created_at").notNull(),
   archivedAt: integer("archived_at"),
 });
@@ -123,3 +127,19 @@ export const wakes = sqliteTable(
   },
   (t) => [index("wakes_agent_fired").on(t.agentId, t.firedAt)],
 );
+
+/**
+ * Durable **ring buffer** of the last N notify events — deliberately NOT a
+ * notification log: rows beyond the cap are pruned on every insert and gone for
+ * good. Sole consumer is the tray's Recent submenu (§12.6), which needs the list to
+ * survive launcher *and* host restarts. Ordered/pruned by the autoincrement `id`
+ * (monotonic, never reused), so same-millisecond `at` ties can't misorder.
+ */
+export const recentNotifications = sqliteTable("recent_notifications", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  kind: text("kind").notNull(),
+  title: text("title").notNull(),
+  body: text("body").notNull(),
+  agentId: text("agent_id"),
+  at: integer("at").notNull(),
+});

--- a/app/src/main/host/index.ts
+++ b/app/src/main/host/index.ts
@@ -27,6 +27,7 @@ import { CodexAppServerManager } from "../services/harness/codex-app-server";
 import { buildCodexAnswerer, buildInteractivePushFactory } from "../services/harness/codex-gate";
 import { LocalApiServer } from "../services/local-api";
 import { derivePort } from "../services/local-api/endpoint";
+import { RecentNotificationsService } from "../services/notifications/recent";
 import { Scheduler } from "../services/scheduler";
 import {
   CodexHeadlessStrategy,
@@ -71,6 +72,11 @@ async function main() {
   registry.resetStatusesOnBoot();
 
   const settings = new SettingsService(db);
+  // Durable Recent ring buffer for the tray (§12.6). Subscribed HERE, before anything
+  // that can emit `notify` — the scheduler's boot catch-up sweep (scheduler.start()
+  // below) fires wake notifications synchronously, and the broker auto-connect can too.
+  const recent = new RecentNotificationsService(db);
+  recent.start();
   // Single telemetry funnel — wired early so the gui:present / settings:changed
   // listeners are live before the GUI connects. Inert without a build-time key
   // and in dev (unless OPENTRADE_ANALYTICS_DEV=1).
@@ -198,6 +204,7 @@ async function main() {
     settings,
     scheduler,
     wake,
+    recent,
   };
   const trpc = new HostTrpcServer(ctx, token);
   await trpc.listen();

--- a/app/src/main/host/manifest.ts
+++ b/app/src/main/host/manifest.ts
@@ -97,13 +97,16 @@ export async function liveHost(): Promise<HostManifest | null> {
 const versionOf = (m: HostManifest): string => m.version ?? "0.0.0";
 
 /**
- * Retire a host whose code is stale (its version differs from the launcher's —
- * e.g. right after an auto-update, when the old detached host is still running).
- * SIGTERM it and wait for it to exit (it has a graceful handler that clears the
- * manifest), so the fresh build can reclaim the stable faucet port and spawn a
- * host running the new code.
+ * SIGTERM the host and wait for it to exit — its graceful handler tears down
+ * everything it owns (scheduler, in-flight headless wakes + their spawn markers,
+ * codex app-servers, PTYs, servers) and clears the manifest. A host still alive
+ * after the grace window gets SIGKILL — and the manifest is only cleared once the
+ * pid is actually dead: erasing it while a wedged host lives would let the next
+ * launch spawn a second host that fights the orphan over the stable faucet port.
+ * Two callers: `ensureHost` retiring a stale-version host after an auto-update,
+ * and the launcher's "Quit OpenTrade Completely" (§12.6).
  */
-async function terminateStaleHost(m: HostManifest): Promise<void> {
+export async function terminateHost(m: HostManifest): Promise<void> {
   try {
     process.kill(m.pid, "SIGTERM");
   } catch {
@@ -113,7 +116,15 @@ async function terminateStaleHost(m: HostManifest): Promise<void> {
     if (!isAlive(m.pid)) break;
     await delay(100);
   }
-  clearManifest();
+  if (isAlive(m.pid)) {
+    try {
+      process.kill(m.pid, "SIGKILL");
+    } catch {
+      // died between the check and the kill
+    }
+    for (let i = 0; i < 20 && isAlive(m.pid); i++) await delay(100);
+  }
+  if (!isAlive(m.pid)) clearManifest();
 }
 
 /**
@@ -177,7 +188,7 @@ export async function ensureHost(
     const m = await liveHost();
     if (!m) return null;
     if (versionOf(m) === expectedVersion) return m;
-    await terminateStaleHost(m);
+    await terminateHost(m); // stale version (post-update) — retire before respawning
     return null;
   };
 

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,13 +1,22 @@
 import { join } from "node:path";
+import type { Agent } from "@shared/agent";
 import { errorNameOf, sanitizeStack } from "@shared/analytics";
-import type { HostNotification, NotificationKind } from "@shared/notify";
+import type { HostNotification, NotificationKind, RecentNotification } from "@shared/notify";
 import { type AppSettings, DEFAULT_SETTINGS } from "@shared/settings";
+import { SHELL_IPC } from "@shared/shell";
 import { createTRPCClient, createWSClient, wsLink } from "@trpc/client";
-import { app, BrowserWindow, Notification } from "electron";
+import { app, BrowserWindow, ipcMain, Notification, powerMonitor } from "electron";
 import superjson from "superjson";
 import { WebSocket as NodeWebSocket } from "ws";
 import { OPENTRADE_HOME } from "./db/client";
-import { ensureHost, type HostManifest } from "./host/manifest";
+import {
+  ensureHost,
+  type HostManifest,
+  isAlive,
+  readManifest,
+  terminateHost,
+} from "./host/manifest";
+import { AppTray } from "./tray";
 import type { AppRouter } from "./trpc/routers";
 import { initAutoUpdate } from "./updater";
 import { createMainWindow } from "./window";
@@ -15,11 +24,25 @@ import { createMainWindow } from "./window";
 let mainWindow: BrowserWindow | null = null;
 let relayClient: ReturnType<typeof createWSClient> | null = null;
 let relayTrpc: ReturnType<typeof createTRPCClient<AppRouter>> | null = null;
-/** The adopted host, kept so a notification click can recreate a closed window. */
+/** The adopted host, kept so a notification/tray click can recreate a closed window. */
 let currentHost: HostManifest | null = null;
-/** Live AppSettings mirror driven by `settings.onChanged`; gates notification display.
- *  Seeded with defaults (all on) so display works before the first push arrives. */
+/** Live AppSettings mirror driven by `settings.onChanged`; gates notification display
+ *  and the menu bar item. Seeded with defaults (all on) so both work before the first
+ *  push arrives. */
 let liveSettings: AppSettings = DEFAULT_SETTINGS;
+/** Set when a *real* quit is underway (tray Quit, updater relaunch, OS shutdown/logout).
+ *  While false and the menu bar item is on, ⌘Q retreats to the menu bar instead (§12.6). */
+let quitting = false;
+/** Whether the quit in flight is the UPDATER's relaunch — only that quit may be rolled
+ *  back by the updater's `onError` (a failed quitAndInstall); see the handler. */
+let updaterRelaunching = false;
+/** Agent the tray asked the renderer to select, with the time of the click. Consumed by
+ *  the renderer's mount-time pull; cleared when the window closes. The pull only exists
+ *  for a renderer that mounts *because of* that click, so it expires — otherwise a much
+ *  later renderer reload (a crash auto-reload, a dev refresh) would pull a stale id and
+ *  jump the view for no reason. */
+let pendingSelect: { agentId: string; at: number } | null = null;
+const PENDING_SELECT_TTL_MS = 30_000;
 
 /** AppSettings toggle backing each notification kind. */
 const NOTIFY_TOGGLE: Record<NotificationKind, keyof AppSettings> = {
@@ -30,22 +53,134 @@ const NOTIFY_TOGGLE: Record<NotificationKind, keyof AppSettings> = {
   update: "notifyUpdates",
 };
 
+/** The macOS menu bar item is a darwin-only affordance (elsewhere the app quits with its
+ *  last window anyway). Toggled live by the `showInMenuBar` setting. Off when the host
+ *  never came up: there's nothing to monitor, and the BackendFailed screen tells the user
+ *  to quit + reopen — ⌘Q must really quit for that recovery to work. */
+function menuBarEnabled(): boolean {
+  return (
+    process.platform === "darwin" && liveSettings.showInMenuBar && (currentHost?.trpcPort ?? 0) > 0
+  );
+}
+
 /** True only when a live (non-destroyed) window exists and is focused. */
 function windowFocused(): boolean {
   return mainWindow !== null && !mainWindow.isDestroyed() && mainWindow.isFocused();
 }
 
+/**
+ * Create the main window and wire everything that is per-*window* (not per-launcher):
+ * the focus/blur → broker cadence relay and the `closed` bookkeeping. Every creation
+ * site goes through here — boot, dock `activate`, notification click, tray click — so a
+ * recreated window behaves exactly like the first one.
+ */
+function openWindow(host: HostManifest): BrowserWindow {
+  const win = createMainWindow({ trpcPort: host.trpcPort, token: host.token });
+  mainWindow = win;
+  win.on("closed", () => {
+    if (mainWindow === win) {
+      mainWindow = null;
+      // An undelivered tray selection is moot once its window is gone, and a delivered
+      // one must not leak into the next mount's pull.
+      pendingSelect = null;
+    }
+  });
+  // Relay window focus to the host so it polls the broker at the fast cadence only
+  // while the user is watching (the host defaults to the blurred cadence). The
+  // window opens focused, so assert that once, then track focus/blur.
+  const setFocused = (focused: boolean) =>
+    relayTrpc?.broker.setFocused.mutate({ focused }).catch(() => {});
+  setFocused(true);
+  win.on("focus", () => setFocused(true));
+  win.on("blur", () => setFocused(false));
+  return win;
+}
+
 /** Restore/show/focus the window, recreating it if it was closed — on macOS the app
- *  outlives its window, so a click on a wake notification must be able to reopen it. */
+ *  outlives its window, so a click on a wake notification or the tray must be able to
+ *  reopen it. Also brings the dock icon back if we had retreated to the menu bar. */
 function focusMainWindow(): void {
+  // Menu-bar mode hides the dock icon; a visible window wants it back (and the app
+  // has to be a regular app again to reliably come to the front).
+  void app.dock?.show();
   if (!mainWindow || mainWindow.isDestroyed()) {
     if (!currentHost) return;
-    mainWindow = createMainWindow({ trpcPort: currentHost.trpcPort, token: currentHost.token });
+    const win = openWindow(currentHost);
+    win.once("ready-to-show", () => app.focus({ steal: true }));
     return;
   }
   if (mainWindow.isMinimized()) mainWindow.restore();
   mainWindow.show();
   mainWindow.focus();
+  app.focus({ steal: true });
+}
+
+/** Open the window *and* select an agent — a tray-menu click on an agent row (§12.6
+ *  shell bridge). Push + pull: the push reaches a mounted renderer; a still-loading
+ *  renderer (or one this call just created) drops it and pulls `pendingSelectAgent` on
+ *  mount instead. A mounted renderer may get both — its apply is idempotent. */
+function openAgent(agentId: string): void {
+  pendingSelect = { agentId, at: Date.now() };
+  focusMainWindow();
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(SHELL_IPC.selectAgent, agentId);
+  }
+}
+
+/** Close the window(s): the launcher lives on as the menu bar item only. What ⌘Q /
+ *  dock-Quit do while `showInMenuBar` is on. The dock icon is dropped by the
+ *  `window-all-closed` handler this triggers — the same path the red button takes. */
+function retreatToMenuBar(): void {
+  for (const w of BrowserWindow.getAllWindows()) w.close();
+}
+
+/** Really exit the launcher (the host is detached and keeps running regardless). */
+function quitForReal(): void {
+  quitting = true;
+  app.quit();
+}
+
+/**
+ * Full quit: stop the backend host, then exit the launcher — nothing keeps running.
+ * One SIGTERM tears down the whole tree (the host's graceful handler kills in-flight
+ * headless wakes + clears their spawn markers so no agent gets marked broken, stops
+ * codex app-servers and PTYs, and clears the manifest); the next launch respawns a
+ * fresh host via `ensureHost`. Shared by the tray row and the Settings button.
+ */
+async function quitCompletely(): Promise<void> {
+  quitting = true; // set BEFORE the await — a ⌘Q racing the teardown must not retreat
+  const host = currentHost;
+  // Revalidate the boot-time pid before signalling it: the launcher can sit in the
+  // menu bar for days, so the host may have died since and the OS reused the pid —
+  // the manifest must still name it AND it must still be alive.
+  if (host && host.pid > 0 && readManifest()?.pid === host.pid && isAlive(host.pid)) {
+    try {
+      await terminateHost(host);
+    } catch (err) {
+      console.error("[launcher] host termination failed", err);
+    }
+  }
+  quitForReal();
+}
+
+/** The status item. Constructed eagerly (cheap; no Tray until `show()`), fed by the
+ *  relay below, shown/hidden by `applyMenuBar` as the setting changes. */
+const tray = new AppTray({
+  openWindow: focusMainWindow,
+  openAgent,
+  quit: quitForReal,
+  quitCompletely: () => void quitCompletely(),
+});
+
+/** Reconcile the tray with the live setting. Turning it off while retreated would leave
+ *  no way back into the app, so that path also restores the dock icon. */
+function applyMenuBar(): void {
+  if (menuBarEnabled()) {
+    tray.show();
+  } else {
+    tray.hide();
+    void app.dock?.show();
+  }
 }
 
 /** The single display path for every notification kind: gate on the per-kind toggle,
@@ -76,12 +211,10 @@ if (!app.requestSingleInstanceLock()) {
   // (The backend host is separate and keeps running regardless.)
   app.quit();
 } else {
-  app.on("second-instance", () => {
-    if (!mainWindow) return;
-    if (mainWindow.isMinimized()) mainWindow.restore();
-    mainWindow.show();
-    mainWindow.focus();
-  });
+  // A second launch (Finder / Spotlight / `open -a`) is how a user reaches a launcher
+  // that has retreated to the menu bar and hidden its dock icon — so it must be able
+  // to recreate the window, not just focus an existing one.
+  app.on("second-instance", () => focusMainWindow());
   app.whenReady().then(main);
 }
 
@@ -103,13 +236,28 @@ async function main() {
   }
   currentHost = host;
 
-  const win = createMainWindow({ trpcPort: host.trpcPort, token: host.token });
-  mainWindow = win;
-  win.on("closed", () => {
-    if (mainWindow === win) mainWindow = null;
+  // Shell bridge (§12.6): a renderer created *by* a tray click pulls the agent it
+  // should select once it mounts (the push would have preceded its listener).
+  ipcMain.handle(SHELL_IPC.takePendingAgent, () => {
+    const pending = pendingSelect;
+    pendingSelect = null;
+    if (!pending || Date.now() - pending.at > PENDING_SELECT_TTL_MS) return null;
+    return pending.agentId;
   });
+  // Settings → General "Quit completely": same path as the tray row.
+  ipcMain.handle(SHELL_IPC.quitCompletely, () => quitCompletely());
 
-  if (host.trpcPort) wireNotifications(win, host);
+  const win = openWindow(host);
+
+  if (host.trpcPort) wireNotifications(host);
+  // The menu bar item first appears from the initial `settings.onChanged` push (sub-
+  // second; emit-on-subscribe), NOT eagerly here: seeding from the default-on setting
+  // flashed the tray for users who disabled it — and while that flash lasted, ⌘Q
+  // retreated to a menu bar they'd turned off instead of quitting.
+
+  // OS shutdown / restart / logout must not be blocked by the ⌘Q intercept: lift it
+  // and go. (`powerMonitor` is only usable after `ready`.)
+  powerMonitor.on("shutdown", () => quitForReal());
 
   // App updates against GitHub Releases (no-op in dev / unpackaged). User-in-charge:
   // we check on boot + every 4h but never auto-download or install-on-quit — the
@@ -126,6 +274,16 @@ async function main() {
     // sanitized `app_error` (subsystem "updater") — class name + bundle frames only,
     // never the message — so update failures are triageable alongside other daemon errors.
     onError: (err) => {
+      // A failed `quitAndInstall` means no relaunch is happening after all — undo the
+      // flag `onWillRelaunch` set so ⌘Q doesn't permanently quit instead of retreating.
+      // Scoped to relaunches the UPDATER initiated: `error` also fires for routine
+      // check/download failures, and blindly clearing `quitting` there would flip an
+      // unrelated in-flight real quit (quitCompletely's await window, OS shutdown)
+      // back into a retreat — during logout, a preventDefault against the OS.
+      if (updaterRelaunching) {
+        updaterRelaunching = false;
+        quitting = false;
+      }
       const frames = sanitizeStack(err);
       relayTrpc?.analytics.track
         .mutate({
@@ -145,22 +303,58 @@ async function main() {
     // real show (a focus-suppressed one leaves the next background re-check free to fire).
     showNotification: (title, body) =>
       windowFocused() ? false : showAppNotification("update", title, body),
+    // The relaunch is a real quit — don't let the menu-bar intercept swallow it.
+    onWillRelaunch: () => {
+      updaterRelaunching = true;
+      quitting = true;
+    },
   });
 
+  // Dock click with no window → recreate it (through the same path as every other
+  // reopen, so a hidden dock icon comes back too).
   app.on("activate", () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      mainWindow = createMainWindow({ trpcPort: host.trpcPort, token: host.token });
-    }
+    if (BrowserWindow.getAllWindows().length === 0) focusMainWindow();
   });
 }
 
 // macOS: closing the window does not quit the app. The backend host is detached
 // and survives regardless, so agent sessions keep running with the GUI closed.
+// With the menu bar item on, "no window" also means "no dock icon" — the status
+// item *is* the app until the user opens it again (§12.6).
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") app.quit();
+  if (process.platform !== "darwin") {
+    app.quit();
+    return;
+  }
+  // Same guard as the quit intercept: only go dockless when there's a status item
+  // left to reach the app through.
+  if (tray.visible) app.dock?.hide();
 });
 
-app.on("before-quit", () => {
+// A signal is an explicit "exit" from outside — dev.sh, `kill`, the terminal's ^C, a
+// logout Electron didn't translate — and must never be swallowed into the menu-bar
+// retreat. Electron's default signal handling funnels into `before-quit` (where the
+// intercept below would catch it and orphan the tray); registering our own listeners
+// replaces that path so a signal always really exits.
+for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) process.on(sig, quitForReal);
+
+app.on("before-quit", (e) => {
+  // ⌘Q / dock-Quit with the menu bar item showing: don't exit — retreat to the menu bar
+  // so agent status + notifications keep flowing while the app is "closed". A real exit
+  // comes from the tray's Quit, the updater's relaunch, OS shutdown, or a signal
+  // (`quitting`). The guard is the tray's ACTUAL visibility, not just the setting: a
+  // retreat with no status item to retreat *to* would leave no window, no dock icon and
+  // no way back in. (They can diverge — e.g. the host is up, so the setting says yes,
+  // but the relay never connected and `applyMenuBar` never ran.)
+  if (tray.visible && !quitting) {
+    e.preventDefault();
+    retreatToMenuBar();
+    // Still drop the broker to the blurred cadence: the user is gone even though the
+    // process isn't. (Closing the window emits `blur` too, but that's a Chromium
+    // detail, not a contract.)
+    relayTrpc?.broker.setFocused.mutate({ focused: false }).catch(() => {});
+    return;
+  }
   // GUI going away → drop the broker to the blurred poll cadence. We do NOT tear
   // down PTYs here: the host's gui-presence detector already fires on the renderer
   // WS dropping (covers Cmd-Q, window-close, and crash uniformly) and tears down
@@ -172,16 +366,18 @@ app.on("before-quit", () => {
 
 /**
  * Notification relay. All app state lives in the backend host, so macOS
- * notifications, the dock badge, and the focus relay are driven by a small
- * tRPC-over-WS client — out of the data path. The host formats notifications
- * (`notifications.onNotify`); this launcher gates them (per-kind toggle, per-agent
- * mute, window focus for wakes) and displays them. The approval badge/flash stay
- * unconditional — only the approval *banner* is gated (§12.4).
+ * notifications, the dock badge, the menu bar item, and the focus relay are driven
+ * by a small tRPC-over-WS client — out of the data path. The host formats
+ * notifications (`notifications.onNotify`); this launcher gates them (per-kind
+ * toggle, per-agent mute, window focus for wakes) and displays them. The approval
+ * badge/flash stay unconditional — only the approval *banner* is gated (§12.4). The
+ * same streams feed the tray (§12.6), ungated: it's a monitor, not an interruption.
  */
-function wireNotifications(win: BrowserWindow, host: HostManifest) {
+function wireNotifications(host: HostManifest) {
   const wsClient = createWSClient({
     // Tag this connection `&client=relay` so the host's gui-presence detector
     // excludes it — only true renderer connections count as "GUI present" (§12.2).
+    // That's also what lets a menu-bar-only launcher leave the host in headless mode.
     url: `ws://127.0.0.1:${host.trpcPort}?token=${encodeURIComponent(host.token)}&client=relay`,
     // Electron main is a Node context; supply a WebSocket implementation.
     WebSocket: NodeWebSocket as unknown as typeof WebSocket,
@@ -192,28 +388,32 @@ function wireNotifications(win: BrowserWindow, host: HostManifest) {
   });
   relayTrpc = client;
 
-  // Relay window focus to the host so it polls the broker at the fast cadence only
-  // while the user is watching (the host defaults to the blurred cadence). The
-  // window opens focused, so assert that once, then track focus/blur.
-  const setFocused = (focused: boolean) =>
-    client.broker.setFocused.mutate({ focused }).catch(() => {});
-  setFocused(true);
-  win.on("focus", () => setFocused(true));
-  win.on("blur", () => setFocused(false));
+  // The boot window opens focused (its own focus/blur handlers were bound before the
+  // relay existed, so assert the initial state here once).
+  client.broker.setFocused.mutate({ focused: true }).catch(() => {});
 
-  // Keep the notification gate live. `settings.onChanged` pushes the current
-  // settings immediately on (re)connect, so this both seeds and refreshes the cache
-  // and self-heals across a relay reconnect — no separate `get` query needed.
+  // Keep the notification gate + menu bar toggle live. `settings.onChanged` pushes the
+  // current settings immediately on (re)connect, so this both seeds and refreshes the
+  // cache and self-heals across a relay reconnect — no separate `get` query needed.
   client.settings.onChanged.subscribe(undefined, {
     onData: (s: AppSettings) => {
       liveSettings = s;
+      applyMenuBar();
     },
   });
 
+  // Agent list + statuses → the tray's per-agent rows (pushed on every change).
+  client.agents.onChanged.subscribe(undefined, {
+    onData: (list: Agent[]) => tray.setAgents(list),
+  });
+
+  // Seeded by `approvals.onChanged` below — it emits on subscribe, like the other
+  // subscriptions, so no eager call is needed here.
   const updateBadge = async () => {
     try {
       const n = await client.approvals.pendingCount.query();
       app.dock?.setBadge(n > 0 ? String(n) : "");
+      tray.setPendingCount(n);
     } catch {
       // host briefly unreachable — leave the badge as-is
     }
@@ -221,17 +421,28 @@ function wireNotifications(win: BrowserWindow, host: HostManifest) {
 
   // Approval alerts: the dock badge + frame flash + window focus are unconditional
   // (the user asked for an approval; they need to see it). Only the banner is gated,
-  // and that happens on the `notify` stream below.
+  // and that happens on the `notify` stream below. With no window (menu-bar mode) the
+  // tray title carries the count instead — we deliberately don't pop the window open.
   client.approvals.onPending.subscribe(undefined, {
     onData: () => {
-      if (!windowFocused()) win.flashFrame(true);
-      win.focus();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        if (!mainWindow.isFocused()) mainWindow.flashFrame(true);
+        mainWindow.focus();
+      }
       void updateBadge();
     },
   });
 
   client.approvals.onChanged.subscribe(undefined, {
     onData: () => void updateBadge(),
+  });
+
+  // The tray's Recent list, straight from the host's durable ring buffer: the full
+  // list on (re)connect and on every change, so it survives a launcher quit and a host
+  // restart. Fed pre-gate on the host side — muting a banner shouldn't erase the event
+  // from the monitor you deliberately opened.
+  client.notifications.onRecent.subscribe(undefined, {
+    onData: (list: RecentNotification[]) => tray.setRecent(list),
   });
 
   // Host-formatted notification banners. The host owns the copy; the launcher gates

--- a/app/src/main/services/agents/registry.test.ts
+++ b/app/src/main/services/agents/registry.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import type { Db } from "../../db/client";
+import { SCHEMA_DDL } from "../../db/ddl";
 import * as schema from "../../db/schema";
 
 // Isolate OPENTRADE_HOME to a throwaway dir before the registry module (which derives
@@ -18,16 +19,16 @@ beforeAll(async () => {
 });
 afterAll(() => rmSync(HOME, { recursive: true, force: true }));
 
-function memRegistry() {
+/** Build the real schema instead of a hand-maintained subset — SCHEMA_DDL is
+ *  dependency-free precisely so tests can do this, and it can't drift from production. */
+function memDb(): { db: Db; sqlite: Database } {
   const sqlite = new Database(":memory:");
-  sqlite.exec(`CREATE TABLE agents (
-    id TEXT PRIMARY KEY, slug TEXT NOT NULL, name TEXT NOT NULL, template TEXT NOT NULL,
-    harness TEXT NOT NULL DEFAULT 'claude',
-    approval_mode TEXT NOT NULL, last_session_id TEXT, status TEXT NOT NULL,
-    headless_turns_used INTEGER NOT NULL DEFAULT 0,
-    turn_limit_enabled INTEGER NOT NULL DEFAULT 1,
-    created_at INTEGER NOT NULL, archived_at INTEGER);`);
-  return new AgentRegistry(drizzle(sqlite, { schema }) as unknown as Db);
+  sqlite.exec(SCHEMA_DDL);
+  return { db: drizzle(sqlite, { schema }) as unknown as Db, sqlite };
+}
+
+function memRegistry() {
+  return new AgentRegistry(memDb().db);
 }
 
 describe("AgentRegistry — executionState", () => {
@@ -197,6 +198,13 @@ describe("AgentRegistry — codex scaffold divergence", () => {
     expect(pre.hooks[0].timeout).toBe(600);
     expect(existsSync(join(codexHome, "hooks", "approval-gate.sh"))).toBe(true);
     expect(existsSync(join(codexHome, "hooks", "order-result.sh"))).toBe(true);
+    // Stop = the turn-ended stamp (codex's only status hook — it has no
+    // Notification event). No matcher: fires on every turn end.
+    const stop = hooks.hooks.Stop[0];
+    expect(stop.matcher).toBeUndefined();
+    expect(stop.hooks[0].command).toContain(join(codexHome, "hooks", "status-notify.sh"));
+    expect(stop.hooks[0].command).toContain("OPENTRADE_AGENT_ID=");
+    expect(existsSync(join(codexHome, "hooks", "status-notify.sh"))).toBe(true);
 
     // codexHomeFor resolves under the REAL ~/.opentrade/cx (keyed by a hash, not
     // OPENTRADE_HOME — the socket-path length constraint), so this test writes outside
@@ -250,5 +258,63 @@ describe("AgentRegistry — codex scaffold divergence", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("AgentRegistry — lastActiveAt (= last_turn_at)", () => {
+  /** Insert an agent row directly — create() would scaffold a real folder. */
+  function seedAgent(sqlite: Database, id: string) {
+    sqlite.exec(
+      `INSERT INTO agents (id, slug, name, template, approval_mode, status, created_at)
+       VALUES ('${id}', '${id}', '${id}', 'default', 'approve', 'idle', 1)`,
+    );
+  }
+
+  test("null until the agent's first turn; markAgentTurn is the only writer", () => {
+    const { db, sqlite } = memDb();
+    const r = new AgentRegistry(db);
+    seedAgent(sqlite, "a");
+    expect(r.get("a")?.lastActiveAt).toBe(null);
+
+    // Wake/audit history alone does NOT move it — `lastActiveAt` is the stamp
+    // column, not a derivation (the scheduler stamps via markAgentTurn at fire).
+    sqlite.exec(
+      `INSERT INTO wakes (id, agent_id, source_kind, prompt, background, fired_at)
+       VALUES ('w1', 'a', 'cron', 'go', 1, 1000)`,
+    );
+    sqlite.exec(
+      `INSERT INTO audit_log (agent_id, kind, payload, at) VALUES ('a', 'order_intent', '{}', 500)`,
+    );
+    expect(r.get("a")?.lastActiveAt).toBe(null);
+
+    const before = Date.now();
+    r.markAgentTurn("a");
+    const at = r.get("a")?.lastActiveAt;
+    expect(at).toBeGreaterThanOrEqual(before);
+  });
+
+  test("the agent-turn stamp is durable — it survives losing the registry instance", () => {
+    // The host restarts on every app update, so an in-memory stamp would snap every
+    // agent back to its last wake/audit time. Same DB, fresh registry = that restart.
+    const { db, sqlite } = memDb();
+    seedAgent(sqlite, "a");
+    new AgentRegistry(db).markAgentTurn("a");
+
+    const afterRestart = new AgentRegistry(db).get("a")?.lastActiveAt;
+    expect(afterRestart).toBeGreaterThan(0);
+    expect(sqlite.query("SELECT last_turn_at FROM agents WHERE id='a'").get()).toEqual({
+      last_turn_at: afterRestart,
+    });
+  });
+
+  test("is per-agent and rides list()", () => {
+    const { db, sqlite } = memDb();
+    const r = new AgentRegistry(db);
+    seedAgent(sqlite, "a");
+    seedAgent(sqlite, "b");
+    r.markAgentTurn("a");
+    const list = r.list();
+    expect(list.find((x) => x.id === "a")?.lastActiveAt).toBeGreaterThan(0);
+    expect(list.find((x) => x.id === "b")?.lastActiveAt).toBe(null);
   });
 });

--- a/app/src/main/services/agents/registry.ts
+++ b/app/src/main/services/agents/registry.ts
@@ -82,13 +82,36 @@ export class AgentRegistry {
       .select()
       .from(agentsTable)
       .all()
-      .map((r) => rowToAgent(r, this.executionStateOf(r.id)))
+      .map((r) => rowToAgent(r, this.executionStateOf(r.id), r.lastTurnAt))
       .filter((a) => a.archivedAt === null);
   }
 
   get(id: string): Agent | undefined {
     const row = this.db.select().from(agentsTable).where(eq(agentsTable.id, id)).get();
-    return row ? rowToAgent(row, this.executionStateOf(id)) : undefined;
+    if (!row) return undefined;
+    return rowToAgent(row, this.executionStateOf(id), row.lastTurnAt);
+  }
+
+  /**
+   * Record that the agent just did something: its turn ended (both harnesses' Stop
+   * hook, §6.7), or a background wake fired for it (the coordinator — a turn that
+   * dies mid-flight still leaves its start stamp). `last_turn_at` is the SINGLE
+   * source of `lastActiveAt`; deliberately NOT called for a user message — "last
+   * active" tracks the agent, not the person. Null until the agent's first turn
+   * after the column shipped (v5): the tray just omits the time part.
+   *
+   * Persisted, not in-memory: a host restart would otherwise wipe it and snap every
+   * agent back to its last wake/audit time — and an app update forces a host restart
+   * by design (`ensureHost` retires a version-mismatched host, §14).
+   *
+   * Broadcasts on its own: the status hook that calls this only produces an
+   * `agents:changed` when the arbiter's *winner* changes, and a turn ending with no
+   * status change (the common interactive case) would otherwise leave the tray showing
+   * a stale time until something unrelated moved.
+   */
+  markAgentTurn(id: string): void {
+    this.db.update(agentsTable).set({ lastTurnAt: Date.now() }).where(eq(agentsTable.id, id)).run();
+    this.broadcast();
   }
 
   executionStateOf(id: string): ExecutionState {
@@ -371,7 +394,11 @@ export class AgentRegistry {
   }
 }
 
-function rowToAgent(row: typeof agentsTable.$inferSelect, executionState: ExecutionState): Agent {
+function rowToAgent(
+  row: typeof agentsTable.$inferSelect,
+  executionState: ExecutionState,
+  lastActiveAt: number | null,
+): Agent {
   return {
     id: row.id,
     slug: row.slug,
@@ -382,6 +409,7 @@ function rowToAgent(row: typeof agentsTable.$inferSelect, executionState: Execut
     lastSessionId: row.lastSessionId,
     status: row.status as Agent["status"],
     executionState,
+    lastActiveAt,
     headlessTurnsUsed: row.headlessTurnsUsed,
     turnLimitEnabled: row.turnLimitEnabled,
     createdAt: row.createdAt,

--- a/app/src/main/services/analytics/index.ts
+++ b/app/src/main/services/analytics/index.ts
@@ -43,6 +43,7 @@ const REPORTABLE_SETTING_KEYS = [
   "notifyApprovals",
   "notifyRestricted",
   "notifyUpdates",
+  "showInMenuBar",
 ] as const;
 // `notifyMutedAgents` is intentionally excluded — it carries agent ids, not a
 // categorical/boolean value, so it isn't in the `settingKey` telemetry enum.

--- a/app/src/main/services/event-bus.ts
+++ b/app/src/main/services/event-bus.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import type { Agent } from "@shared/agent";
 import type { Approval } from "@shared/approval";
 import type { BrokerConnectionStatus } from "@shared/broker";
-import type { HostNotification } from "@shared/notify";
+import type { HostNotification, RecentNotification } from "@shared/notify";
 import type { AppSettings } from "@shared/settings";
 
 /** Typed app-wide event bus bridged into tRPC observables. */
@@ -28,6 +28,8 @@ export interface AppEvents {
   /** A host-formatted macOS notification; the launcher relay gates it (per-kind
    *  toggle, per-agent mute, window focus for wakes) and displays it (§12.4). */
   notify: HostNotification;
+  /** The durable Recent ring buffer changed — full list, newest first (§12.6). */
+  "notifications:recent": RecentNotification[];
   /** The last renderer (GUI) disconnected (≥1→0, after a short grace). The host
    *  blanket-kills every interactive PTY so none are maintained outside the GUI. */
   "gui:gone": undefined;

--- a/app/src/main/services/harness/codex.ts
+++ b/app/src/main/services/harness/codex.ts
@@ -236,7 +236,11 @@ export function createCodexHarness(manager: CodexAppServerManager): Harness {
 
       // hooks.json — the claude-compatible format codex reads from CODEX_HOME
       // (which is OUTSIDE the agent dir; the agent only sees its effects).
-      // PreToolUse = the redundant gate layer; PostToolUse = order-outcome capture.
+      // PreToolUse = the redundant gate layer; PostToolUse = order-outcome capture;
+      // Stop = the turn-ended stamp (→ `last_turn_at`, §6.7 — codex has no
+      // Notification event, so Stop is its only status hook). Hooks execute on
+      // BOTH transports: the supervised app-server runs turns (and hooks) for
+      // background wakes and the TUI's threads alike.
       // Hook commands are shell strings; codex runs hooks with a CLEANED env, so
       // the non-secret identifiers ride the command itself and the scripts
       // recover port/token from the host manifest ($OPENTRADE_HOME/host.json).
@@ -263,6 +267,17 @@ export function createCodexHarness(manager: CodexAppServerManager): Harness {
                   type: "command",
                   command: `${hookEnv} '${join(hooksDir, "order-result.sh")}'`,
                   timeout: 30,
+                },
+              ],
+            },
+          ],
+          Stop: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: `${hookEnv} '${join(hooksDir, "status-notify.sh")}'`,
+                  timeout: 10,
                 },
               ],
             },

--- a/app/src/main/services/local-api/index.ts
+++ b/app/src/main/services/local-api/index.ts
@@ -218,13 +218,25 @@ export class LocalApiServer {
     const agentId = header(req, "x-opentrade-agent");
     const body = await readJson(req);
     const event = String(body?.hook_event_name ?? "");
-    if (agentId && this.registry.get(agentId)) {
+    const agent = agentId ? this.registry.get(agentId) : undefined;
+    if (agentId && agent) {
+      // Both events are the AGENT speaking (it asked for input / finished its turn),
+      // which is exactly what "last active" should track — a user message produces
+      // neither, so typing at an agent never moves its timestamp (§12.6). Codex
+      // fires Stop only (it has no Notification event); claude fires both.
+      if (event === "Notification" || event === "Stop") {
+        this.registry.markAgentTurn(agentId);
+      }
       if (event === "Notification") {
         this.deps.arbiter.setNeedsInput(agentId, true);
       } else if (event === "Stop") {
         this.deps.arbiter.setNeedsInput(agentId, false);
+        // Session capture is claude-only: for codex, `lastSessionId` is the
+        // app-server THREAD id (minted by thread/start and adopted from the TUI,
+        // §13) — codex's hook `session_id` is not verified to match it, and an
+        // overwrite here would break `thread/resume` for every later wake.
         const sessionId = body?.session_id;
-        if (typeof sessionId === "string" && sessionId) {
+        if (agent.harness === "claude" && typeof sessionId === "string" && sessionId) {
           this.registry.setLastSessionId(agentId, sessionId);
         }
       }

--- a/app/src/main/services/notifications/recent.test.ts
+++ b/app/src/main/services/notifications/recent.test.ts
@@ -1,0 +1,87 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import type { HostNotification } from "@shared/notify";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import type { Db } from "../../db/client";
+import { SCHEMA_DDL } from "../../db/ddl";
+import * as schema from "../../db/schema";
+import { bus } from "../event-bus";
+import { RECENT_MAX, RecentNotificationsService } from "./recent";
+
+// better-sqlite3 can't load under Bun's test runner; bun:sqlite exposes the same
+// sync API through drizzle. SCHEMA_DDL is dependency-free so the real schema is used.
+function memDb(): Db {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(SCHEMA_DDL);
+  return drizzle(sqlite, { schema }) as unknown as Db;
+}
+
+function note(n: Partial<HostNotification> = {}): HostNotification {
+  return { kind: "wake", title: "t", body: "b", ...n };
+}
+
+describe("RecentNotificationsService", () => {
+  test("stamps `at` and returns newest first", () => {
+    const s = new RecentNotificationsService(memDb());
+    s.record(note({ title: "first" }), 100);
+    s.record(note({ title: "second" }), 200);
+
+    const list = s.list();
+    expect(list.map((n) => n.title)).toEqual(["second", "first"]);
+    expect(list[0].at).toBe(200);
+  });
+
+  test("keeps only the newest RECENT_MAX — it is a ring buffer, not a log", () => {
+    const s = new RecentNotificationsService(memDb());
+    const total = RECENT_MAX + 3;
+    for (let i = 0; i < total; i++) s.record(note({ title: `n${i}` }), 1000 + i);
+
+    const list = s.list();
+    expect(list).toHaveLength(RECENT_MAX);
+    expect(list[0].title).toBe(`n${total - 1}`); // newest kept
+    expect(list.at(-1)?.title).toBe(`n${total - RECENT_MAX}`); // oldest survivor
+    expect(list.some((n) => n.title === "n0")).toBe(false); // displaced, gone
+  });
+
+  test("round-trips the payload, with agentId omitted when absent", () => {
+    const s = new RecentNotificationsService(memDb());
+    s.record({ kind: "order", title: "Order filled", body: "BUY $5 of NET", agentId: "a1" }, 5);
+    s.record(note({ kind: "approval" }), 6);
+
+    const [withoutAgent, withAgent] = s.list();
+    expect(withAgent).toEqual({
+      kind: "order",
+      title: "Order filled",
+      body: "BUY $5 of NET",
+      agentId: "a1",
+      at: 5,
+    });
+    expect(withoutAgent.kind).toBe("approval");
+    expect(withoutAgent.agentId).toBeUndefined();
+  });
+
+  test("a DB failure never escapes into the emitter", () => {
+    // record() runs inline on the raw `notify` bus, whose emitters are the scheduler,
+    // the broker ledger sync and the approval gate — a throw here would break them.
+    const sqlite = new Database(":memory:"); // no schema: every write fails
+    const s = new RecentNotificationsService(drizzle(sqlite, { schema }) as unknown as Db);
+    expect(() => s.record(note())).not.toThrow();
+  });
+
+  test("start() records raw `notify` bus events and publishes the new list", () => {
+    const s = new RecentNotificationsService(memDb());
+    const off = s.start();
+    const seen: number[] = [];
+    const offList = bus.onEvent("notifications:recent", (list) => seen.push(list.length));
+    try {
+      bus.emitEvent("notify", note({ title: "from the bus" }));
+      expect(s.list()[0].title).toBe("from the bus");
+      expect(s.list()[0].at).toBeGreaterThan(0); // service stamps it; the bus payload has none
+      expect(seen).toEqual([1]);
+    } finally {
+      // The bus is a module singleton — always detach so other suites stay clean.
+      off();
+      offList();
+    }
+  });
+});

--- a/app/src/main/services/notifications/recent.ts
+++ b/app/src/main/services/notifications/recent.ts
@@ -1,0 +1,92 @@
+import type { HostNotification, HostNotificationKind, RecentNotification } from "@shared/notify";
+import { desc, notInArray } from "drizzle-orm";
+import type { Db } from "../../db/client";
+import { recentNotifications } from "../../db/schema";
+import { hostLog } from "../../host/log";
+import { bus } from "../event-bus";
+
+/** How many events the ring buffer keeps — exactly what the tray's Recent shows. */
+export const RECENT_MAX = 10;
+
+/**
+ * Durable ring buffer of the last `RECENT_MAX` notify events, backing the tray's
+ * Recent submenu (§12.6).
+ *
+ * It subscribes to the **raw** `notify` bus, i.e. *before* the launcher's gating
+ * (per-kind toggle, per-agent mute, wake focus rule): muting a banner suppresses an
+ * interruption, it shouldn't blind the monitor you deliberately opened. The bus
+ * payload carries no timestamp, so this is where `at` is stamped.
+ *
+ * Persisted rather than held in memory so Recent survives a launcher quit *and* a
+ * host restart/reboot — the tray is most useful precisely when the app has been
+ * closed for a while. It is a ring buffer, not a log: displaced rows are deleted.
+ */
+export class RecentNotificationsService {
+  constructor(private db: Db) {}
+
+  /**
+   * Start recording. Must be wired BEFORE any service that can emit `notify` runs —
+   * the scheduler's boot catch-up sweep fires synchronously during `start()`.
+   * Returns an unsubscribe fn (used by tests; the host keeps it for its lifetime).
+   */
+  start(): () => void {
+    return bus.onEvent("notify", (n) => this.record(n));
+  }
+
+  /**
+   * Stamp, append, prune beyond the cap, and publish the new list.
+   *
+   * Never throws: this is the first listener on the raw `notify` bus, which the bus
+   * does not isolate, so a DB error escaping here would propagate into the emitter —
+   * the scheduler firing a wake, the broker's ledger sync, the approval gate — and
+   * skip every later listener. A missing Recent row is not worth risking those.
+   */
+  record(n: HostNotification, at: number = Date.now()): void {
+    try {
+      this.write(n, at);
+    } catch (err) {
+      hostLog.error("failed to record recent notification", String(err));
+    }
+  }
+
+  private write(n: HostNotification, at: number): void {
+    this.db
+      .insert(recentNotifications)
+      .values({
+        kind: n.kind,
+        title: n.title,
+        body: n.body,
+        agentId: n.agentId ?? null,
+        at,
+      })
+      .run();
+    // Keep only the newest RECENT_MAX. The host is the single writer and these run
+    // back-to-back synchronously, so no transaction is needed (cf. AuditLog.append).
+    const keep = this.db
+      .select({ id: recentNotifications.id })
+      .from(recentNotifications)
+      .orderBy(desc(recentNotifications.id))
+      .limit(RECENT_MAX)
+      .all()
+      .map((r) => r.id);
+    this.db.delete(recentNotifications).where(notInArray(recentNotifications.id, keep)).run();
+    bus.emitEvent("notifications:recent", this.list());
+  }
+
+  /** Newest first, at most `RECENT_MAX`. */
+  list(): RecentNotification[] {
+    return this.db
+      .select()
+      .from(recentNotifications)
+      .orderBy(desc(recentNotifications.id))
+      .limit(RECENT_MAX)
+      .all()
+      .map((r) => ({
+        kind: r.kind as HostNotificationKind,
+        title: r.title,
+        body: r.body,
+        ...(r.agentId ? { agentId: r.agentId } : {}),
+        at: r.at,
+      }));
+  }
+}

--- a/app/src/main/services/scheduler/index.ts
+++ b/app/src/main/services/scheduler/index.ts
@@ -459,6 +459,9 @@ export class Scheduler {
       source: sourceKind,
       path: background ? "headless" : "warm",
     });
+    // Stamp `last_turn_at` at wake START, not just at the Stop hook: a run that dies
+    // mid-flight (API error — Stop never fires) still moves the tray's "last active".
+    this.registry.markAgentTurn(agentId);
     this.wake.enqueue(agentId, prompt);
     // Surface the new wake + updated last/next-fire times in the Monitor tab live.
     bus.emitEvent("scheduler:changed", { agentId });

--- a/app/src/main/services/scheduler/scheduler.test.ts
+++ b/app/src/main/services/scheduler/scheduler.test.ts
@@ -62,6 +62,7 @@ function stdDeps() {
     get: (id: string) => (id === AGENT.id ? AGENT : undefined),
     agentDir: () => tmpdir(),
     executionStateOf: () => "offline" as const,
+    markAgentTurn: () => {},
   } as unknown as AgentRegistry;
   const localApi = { port: 12345, token: "tok" } as unknown as LocalApiServer;
   return { wake, registry, localApi };
@@ -194,6 +195,7 @@ describe("Scheduler CRUD", () => {
       get: (id: string) => (id === AGENT.id ? AGENT : undefined),
       agentDir: () => tmpdir(),
       executionStateOf: () => "offline" as const,
+      markAgentTurn: () => {},
     } as unknown as AgentRegistry;
     const localApi = { port: 1, token: "t" } as unknown as LocalApiServer;
     scheduler = new Scheduler(db, wake, registry, localApi);
@@ -238,6 +240,7 @@ describe("Scheduler CRUD", () => {
         get: (id: string) => (id === AGENT.id ? AGENT : undefined),
         agentDir: () => tmpdir(),
         executionStateOf: () => execState,
+        markAgentTurn: () => {},
       } as unknown as AgentRegistry;
       const s = new Scheduler(db, wake, registry, {
         port: 1,
@@ -306,6 +309,7 @@ describe("Scheduler CRUD", () => {
       get: (id: string) => (id === AGENT.id ? AGENT : undefined),
       agentDir: () => tmpdir(),
       executionStateOf: () => "offline" as const,
+      markAgentTurn: () => {},
     } as unknown as AgentRegistry;
 
     const notifies: unknown[] = [];

--- a/app/src/main/services/settings/index.ts
+++ b/app/src/main/services/settings/index.ts
@@ -24,6 +24,7 @@ const KEYS: Record<keyof AppSettings, string> = {
   notifyRestricted: "notify_restricted",
   notifyUpdates: "notify_updates",
   notifyMutedAgents: "notify_muted_agents",
+  showInMenuBar: "show_in_menu_bar",
 };
 
 /**
@@ -80,6 +81,7 @@ export class SettingsService {
         KEYS.notifyMutedAgents,
         DEFAULT_SETTINGS.notifyMutedAgents,
       ),
+      showInMenuBar: this.readBool(KEYS.showInMenuBar, DEFAULT_SETTINGS.showInMenuBar),
     };
   }
 

--- a/app/src/main/services/settings/settings.test.ts
+++ b/app/src/main/services/settings/settings.test.ts
@@ -54,6 +54,13 @@ describe("SettingsService", () => {
     expect(s.get().telemetryEnabled).toBe(false);
   });
 
+  test("showInMenuBar defaults on (menu bar item + ⌘Q→menu bar) and round-trips off", () => {
+    const s = new SettingsService(memDb());
+    expect(s.get().showInMenuBar).toBe(true);
+    expect(s.update({ showInMenuBar: false }).showInMenuBar).toBe(false);
+    expect(s.get().showInMenuBar).toBe(false);
+  });
+
   test("ms convenience getters convert seconds", () => {
     const s = new SettingsService(memDb());
     s.update({ pollIntervalFocusedSec: 7, pollIntervalBlurredSec: 12 });

--- a/app/src/main/tray.ts
+++ b/app/src/main/tray.ts
@@ -1,0 +1,204 @@
+import type { Agent, AgentStatus } from "@shared/agent";
+import type { RecentNotification } from "@shared/notify";
+import { Menu, type MenuItemConstructorOptions, nativeImage, Tray } from "electron";
+
+/**
+ * The macOS menu bar (status) item — §12.6.
+ *
+ * A launcher-side monitor over the same relay stream that drives notifications:
+ * per-agent status, the pending-approval count (also shown as the item's title so
+ * it's visible without opening the menu), and a short in-memory log of recent
+ * events (wakes / order results / approvals / turn-limit pauses). It's what lets the
+ * launcher stay useful once the window is gone — with `showInMenuBar` on, ⌘Q and
+ * window-close retreat here instead of exiting, so agents running headless in the
+ * host still surface to the user. State is fed by `main/index.ts`; this module only
+ * renders it and routes clicks back through `TrayActions`.
+ *
+ * Pure presentation: no tRPC, no settings gate — callers decide what to feed.
+ */
+
+/** Click routing back into the launcher (all resolve to "open the window" variants). */
+export interface TrayActions {
+  /** Show/restore/recreate the main window. */
+  openWindow(): void;
+  /** Open the window and select this agent (§12.6 shell bridge). */
+  openAgent(agentId: string): void;
+  /** Really quit the launcher (the host keeps running, as always). */
+  quit(): void;
+  /** Full quit: terminate the backend host too — nothing keeps running. */
+  quitCompletely(): void;
+}
+
+/** Keep menu rows on one line; macOS menus don't wrap. */
+const ROW_MAX = 60;
+const DAY_MS = 86_400_000;
+/** Relative times go stale in a menu that isn't rebuilt; re-render on this cadence. */
+const REFRESH_MS = 60_000;
+
+const STATUS_LABEL: Record<AgentStatus, string> = {
+  working: "Working",
+  idle: "Idle",
+  "needs-input": "Needs input",
+  "awaiting-approval": "Awaiting approval",
+};
+
+// The app mark (app/build/icon.svg) rasterized at 16px (1x) and 32px (2x) — embedded
+// so the tray needs no on-disk asset lookup that differs between dev and the packaged
+// .app. Flagged as a *template* image so macOS recolors it for light/dark menu bars.
+// A template image is read by ALPHA ONLY (every non-transparent pixel is "ink"), so the
+// background must be truly transparent — an opaque white background renders as a solid
+// square. Regenerate: `qlmanage -t -s 512` the SVG (it paints on opaque white and ignores
+// viewBox crops), then luminance→alpha, crop to the mark's bbox, LANCZOS-downsample into
+// a 1px-padded 16/32 square (see docs/TODO.md for the script note).
+const ICON_16 =
+  "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABVklEQVR42q3TPUjWURgF8F/6YgSCUCBJBLnpGtEeOEhLodEgTW6CELi5RkNWCjpktQdBNDS4KVgQgotDk+SgFgnah8hbWG9+LMe4vPESSBcul/v8zznPx/9c/uNqznkG9/AO33CAjxjH2TrsX+Sr+IrP2MUvDGMSG9hBXyOR3mR7glPojNBQvrfgYTB99eTTqOJpXXwurVTQlNgD1NBRAu9jq6hkBl+SbSnxpkJoDY9LgU+YxlRIbzGCN3hf4FpyvsR2KbCd/R09RXwUH5L5aGiXsZc2/vTVjFZcwWyGWMHJYH6HdA2vsZm7SgSqmMdiyqyFVM2/f4aL6IofdnG7FHiOm6lkryi3hhO4lASDWMAqXpQzaMdPTOReye7PUNsK7F3s43y9F64HPFbMBlbwCt24E8xAIyv3p+/1eONGzHSQ/QO3/vUezuFRbHxEXI5HLjQiH3sdAh7NVrWb5tLzAAAAAElFTkSuQmCC";
+const ICON_32 =
+  "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADpklEQVR42sWX24tVZRjGf7P3nqYZtUmIQC8GpAtBJIRwiETvkgwPieFVmgQp6IWCUYQHRMl/QJARVMQLEVT0QkJRBCPNQ2JMgYJW6KCjEB085szee3nzfPLM65q1tgT5wWLttfb7Pe/zPe/h+xa85NFW8n8VaNjzu8Bs3ScBrwMZcA+4AVwETgDf27yI0fKo6l4DlgFngWE5LLrqwCVgFdAVsF7Y+Uzgx+BgGBgCmlr5z8AA8CSHzBXgQ2FVWlB8hPM1ki6BNSVzem7oeTwwFpgMLAEO55DZbNiFJGq6b7HVZsApYAYwRjlw3cC35+BMA44EjL4yEmnlqzUhrWJDju1bwF9S5V+gRxK3h3ivUk4MCWvraDlRtSxv2ITPLX6JeWdQKQNWBAUr9nthIDEvj0Ri32+gaeWvCCyyXmS5sTsQwOaihSTbAWCcfI4YS835d3rXEWzGAu+oLK9Zkp60hcTRrvtBw/8yGlWAC2JYB6YbWBVYAOwDbsrGaz4DfihobKn8JgGPNP9X6xEA9IaMd5kvlzSdDDhX0llT+PbY3Pku2RyL3y5Jv0+yTTOgG3q3SU4TcNZCy08qpzHXDb4VyH2pcdqSJsV4gXIgjYmyz9SmixRIiztjClx2g6t6+Tfwmxn9CXySA1YDuoE7sjtTQKA9JHndsJ+NOyG2TSXcVIth6gPJyXjgbgGBNnP+NvCP8qxhHfI5AnX9cc+ct4+yhbsCZxXjSmhCqKJuhep5jsC10Lc/G8W5ExgHDIYq8NEJrAUemvML5mtECE4Ys3Mle3ibNaVBy51ebVbTgfWWV57IPcBtPfc76DdG4As5qZUQGGME0uY1kNMrmsA24c2y93scdKYlx+EWFeiy1TRyHD8W1ns2d6cpsjiWVr/+HAKmyFG1gECHKsUJXAUOaUufHEpxgkKVNqTXIvBKY3+0IAl9/GRzNuaErQK8qt+7c05IIww7tUkkiVaGLTWvt+83+16p0yEiFZv7sSn1B/BGbFoJcLYMh9QTPrIQVXJa6zJb1QHDqpl6s1SK6UCypOxUtNmyehhYHmyqtsV2hy76dcBcDDyw/rKjKMG99PpCY9ofkspBPg2254F12lW99x8MR7tRSywBbw1l9QDYqzPdBAvJVOVB05zFq89UK/02aDPwhWF3zKzz/aKj201zXg9fT4PKE1p1nidxN/CVvnKyFq/flUtvln0LvMjHaRfwPvCB+n2PnW4fqrlcAo4Bx7X9/qeP0/9lPAXLNXbyrktA3AAAAABJRU5ErkJggg==";
+
+function trayIcon() {
+  const img = nativeImage.createEmpty();
+  img.addRepresentation({ scaleFactor: 1, buffer: Buffer.from(ICON_16, "base64") });
+  img.addRepresentation({ scaleFactor: 2, buffer: Buffer.from(ICON_32, "base64") });
+  img.setTemplateImage(true);
+  return img;
+}
+
+function truncate(s: string, max = ROW_MAX): string {
+  const line = s.replace(/\s+/g, " ").trim();
+  return line.length > max ? `${line.slice(0, max - 1)}…` : line;
+}
+
+function clock(at: number): string {
+  return new Date(at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+/** Coarse "how long ago", for a glanceable one-line sublabel. */
+function relativeTime(at: number, now = Date.now()): string {
+  const minutes = Math.floor(Math.max(0, now - at) / 60_000);
+  if (minutes < 1) return "Now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+export class AppTray {
+  private tray: Tray | null = null;
+  private agents: Agent[] = [];
+  private pending = 0;
+  private recent: RecentNotification[] = [];
+  private refresh: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly actions: TrayActions) {}
+
+  /** Idempotent: create the status item if it isn't showing. */
+  show(): void {
+    if (this.tray) return;
+    this.tray = new Tray(trayIcon());
+    this.tray.setToolTip("OpenTrade");
+    this.render();
+    // Rows carry relative times ("2h ago"), which would otherwise freeze at whatever
+    // the last data push rendered. macOS can't update an open menu, but every reopen
+    // then shows fresh values.
+    this.refresh = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  /** Idempotent: remove the status item (state is kept so a later show() is warm). */
+  hide(): void {
+    if (this.refresh) clearInterval(this.refresh);
+    this.refresh = null;
+    this.tray?.destroy();
+    this.tray = null;
+  }
+
+  get visible(): boolean {
+    return this.tray !== null;
+  }
+
+  setAgents(agents: Agent[]): void {
+    this.agents = agents;
+    this.render();
+  }
+
+  setPendingCount(n: number): void {
+    this.pending = n;
+    this.render();
+  }
+
+  /** Replace the Recent list wholesale — the host owns it (durable ring buffer,
+   *  newest first, already capped), so there is nothing to merge here. */
+  setRecent(list: RecentNotification[]): void {
+    this.recent = list;
+    this.render();
+  }
+
+  private render(): void {
+    if (!this.tray) return;
+    // The pending-approval count rides next to the icon so the one actionable state is
+    // visible without opening the menu (the dock badge is gone once the window closes).
+    this.tray.setTitle(this.pending > 0 ? String(this.pending) : "", {
+      fontType: "monospacedDigit",
+    });
+    this.tray.setContextMenu(Menu.buildFromTemplate(this.template()));
+  }
+
+  private template(): MenuItemConstructorOptions[] {
+    // Opening the app leads: it's the action people reach for, so it sits under the
+    // cursor the moment the menu drops rather than at the far end of the list.
+    const items: MenuItemConstructorOptions[] = [
+      { label: "Open OpenTrade", click: () => this.actions.openWindow() },
+    ];
+
+    if (this.agents.length > 0) {
+      items.push({ type: "separator" });
+      for (const a of this.agents) {
+        items.push({
+          label: truncate(a.name),
+          // `sublabel` is a native NSMenuItem subtitle: darwin-only, macOS >= 14.4,
+          // silently dropped below that — the row then reads as just the agent name.
+          sublabel:
+            a.lastActiveAt !== null
+              ? `${STATUS_LABEL[a.status]} · ${relativeTime(a.lastActiveAt)}`
+              : STATUS_LABEL[a.status],
+          click: () => this.actions.openAgent(a.id),
+        });
+      }
+    }
+
+    items.push({ type: "separator" });
+    if (this.pending > 0) {
+      items.push({
+        label: `${this.pending} order${this.pending === 1 ? "" : "s"} awaiting your approval…`,
+        click: () => this.actions.openWindow(),
+      });
+    }
+    items.push({
+      label: "Recent",
+      submenu:
+        this.recent.length === 0
+          ? [{ label: "No recent activity", enabled: false }]
+          : this.recent.map((ev) => ({
+              label: truncate(`${ev.title} — ${ev.body}`),
+              // Clock time reads naturally for today's events; older ones need the
+              // distance instead. (Sublabel: macOS >= 14.4 — see the agent rows.)
+              sublabel: Date.now() - ev.at < DAY_MS ? clock(ev.at) : relativeTime(ev.at),
+              // The ring buffer outlives agents — an event's agent may have been
+              // archived since, so only select ids still in the live list.
+              click: () =>
+                ev.agentId && this.agents.some((a) => a.id === ev.agentId)
+                  ? this.actions.openAgent(ev.agentId)
+                  : this.actions.openWindow(),
+            })),
+    });
+
+    items.push(
+      { type: "separator" },
+      // Quit = the launcher only (agents keep running headless, the Docker Desktop
+      // model); Completely = the backend host too — the full process tree.
+      { label: "Quit OpenTrade", click: () => this.actions.quit() },
+      { label: "Quit OpenTrade Completely", click: () => this.actions.quitCompletely() },
+    );
+    return items;
+  }
+}

--- a/app/src/main/trpc/routers/notifications.ts
+++ b/app/src/main/trpc/routers/notifications.ts
@@ -1,14 +1,28 @@
-import type { HostNotification } from "@shared/notify";
+import type { HostNotification, RecentNotification } from "@shared/notify";
 import { observable } from "@trpc/server/observable";
 import { bus } from "../../services/event-bus";
 import { publicProcedure, router } from "../trpc";
 
 export const notificationsRouter = router({
   /** Pushes each host-formatted notification to the launcher relay, which gates it
-   *  (per-kind toggle, per-agent mute, window focus for wakes) and displays it (§12.4). */
+   *  (per-kind toggle, per-agent mute, window focus for wakes) and displays it (§12.4).
+   *  Deliberately carries NO backlog on subscribe: a relay reconnect must not re-fire
+   *  banners for events the user already saw. The tray's Recent uses `onRecent` below. */
   onNotify: publicProcedure.subscription(() =>
     observable<HostNotification>((emit) => {
       const off = bus.onEvent("notify", (n) => emit.next(n));
+      return () => off();
+    }),
+  ),
+
+  /** The durable Recent ring buffer (§12.6), newest first: the full list on subscribe
+   *  and again on every change. Emit-on-subscribe (like `settings.onChanged`) is what
+   *  makes the tray self-heal across a relay reconnect — and, because the buffer is
+   *  persisted, repopulate after a launcher or host restart. */
+  onRecent: publicProcedure.subscription(({ ctx }) =>
+    observable<RecentNotification[]>((emit) => {
+      emit.next(ctx.recent.list());
+      const off = bus.onEvent("notifications:recent", (list) => emit.next(list));
       return () => off();
     }),
   ),

--- a/app/src/main/trpc/trpc.ts
+++ b/app/src/main/trpc/trpc.ts
@@ -5,6 +5,7 @@ import type { AgentRegistry } from "../services/agents/registry";
 import type { ApprovalService } from "../services/approvals";
 import type { AuditLog } from "../services/audit";
 import type { BrokerService } from "../services/broker";
+import type { RecentNotificationsService } from "../services/notifications/recent";
 import type { Scheduler } from "../services/scheduler";
 import type { WakeTransport } from "../services/scheduler/wake/types";
 import type { SettingsService } from "../services/settings";
@@ -20,6 +21,8 @@ export interface Context {
   settings: SettingsService;
   scheduler: Scheduler;
   wake: WakeTransport;
+  /** Durable Recent ring buffer behind `notifications.onRecent` (§12.6). */
+  recent: RecentNotificationsService;
 }
 
 const t = initTRPC.context<Context>().create({ transformer: superjson });

--- a/app/src/main/updater.ts
+++ b/app/src/main/updater.ts
@@ -43,6 +43,9 @@ interface UpdaterHooks {
    *  Returns whether a banner was actually shown (false if suppressed by the toggle
    *  or because the window was focused) — the caller only dedupes on a real show. */
   showNotification?: (title: string, body: string) => boolean;
+  /** Called immediately before `quitAndInstall()` relaunches the app. The launcher uses
+   *  it to lift its ⌘Q→menu-bar intercept (§12.6) so the updater's quit isn't swallowed. */
+  onWillRelaunch?: () => void;
 }
 
 let hooks: UpdaterHooks = {};
@@ -116,6 +119,7 @@ function wireEvents(): void {
     // version-aware ensureHost then retires the stale host.
     if (installOnDownloaded) {
       installOnDownloaded = false;
+      hooks.onWillRelaunch?.();
       autoUpdater.quitAndInstall();
     }
   });
@@ -171,6 +175,7 @@ export function checkForUpdatesNow(): UpdaterState {
 export function installNow(): void {
   if (!app.isPackaged) return;
   if (state.status === "downloaded") {
+    hooks.onWillRelaunch?.();
     autoUpdater.quitAndInstall();
     return;
   }

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -1,3 +1,4 @@
+import { SHELL_IPC } from "@shared/shell";
 import { UPDATER_IPC, type UpdaterState } from "@shared/updater";
 import { contextBridge, ipcRenderer } from "electron";
 
@@ -33,4 +34,21 @@ contextBridge.exposeInMainWorld("__opentradeUpdater", {
     ipcRenderer.on(UPDATER_IPC.state, listener);
     return () => ipcRenderer.removeListener(UPDATER_IPC.state, listener);
   },
+});
+
+/**
+ * Shell bridge from the MAIN process (menu bar item, §12.6): lets the launcher steer
+ * the renderer — today, "select this agent" after a tray-menu click. See shared/shell.ts.
+ */
+contextBridge.exposeInMainWorld("__opentradeShell", {
+  /** The agent selection requested before this renderer mounted, if any (consumed). */
+  takePendingAgent: (): Promise<string | null> => ipcRenderer.invoke(SHELL_IPC.takePendingAgent),
+  /** Subscribe to pushed "select agent" requests; returns an unsubscribe fn. */
+  onSelectAgent: (cb: (agentId: string) => void): (() => void) => {
+    const listener = (_e: unknown, agentId: string) => cb(agentId);
+    ipcRenderer.on(SHELL_IPC.selectAgent, listener);
+    return () => ipcRenderer.removeListener(SHELL_IPC.selectAgent, listener);
+  },
+  /** Full quit: stop the backend host, then exit the launcher (Settings → General). */
+  quitCompletely: (): Promise<void> => ipcRenderer.invoke(SHELL_IPC.quitCompletely),
 });

--- a/app/src/renderer/App.tsx
+++ b/app/src/renderer/App.tsx
@@ -5,6 +5,7 @@ import { TerminalPane } from "./components/terminal/TerminalPane";
 import { useAgents } from "./hooks/useAgents";
 import { useSettings } from "./hooks/useSettings";
 import { useShortcuts } from "./hooks/useShortcuts";
+import { useShellSelection } from "./lib/shell";
 import { backendStarted } from "./lib/trpc";
 import { cn } from "./lib/utils";
 import { BackendFailed } from "./screens/BackendFailed";
@@ -26,6 +27,9 @@ export function App() {
   // ⌘T opens the New Agent configuration dialog (create happens from the form).
   // Gated off while the backend is down to match the disabled New Agent button.
   useShortcuts({ "create-agent": backendConnected ? openNewAgent : () => {} });
+
+  // A click on an agent in the macOS menu bar item (launcher-side) selects it here.
+  useShellSelection();
 
   // The launcher couldn't bring up the backend host (trpcPort===0), so nothing can
   // ever load — show the restart screen instead of hanging on a blank background.

--- a/app/src/renderer/lib/shell.ts
+++ b/app/src/renderer/lib/shell.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react";
+import { useUIStore } from "../stores/ui";
+
+/**
+ * Renderer side of the main-process shell bridge (`window.__opentradeShell`, exposed
+ * by the preload; contract in shared/shell.ts). The macOS menu bar item (§12.6) lives
+ * in the launcher; when the user clicks an agent there, main opens/focuses the window
+ * and asks us to select that agent. Two paths: a push for an already-mounted renderer,
+ * and a pull on mount for the case where the click created the window (the push would
+ * have landed before this effect subscribed).
+ */
+declare global {
+  interface Window {
+    __opentradeShell?: {
+      takePendingAgent: () => Promise<string | null>;
+      onSelectAgent: (cb: (agentId: string) => void) => () => void;
+      quitCompletely: () => Promise<void>;
+    };
+  }
+}
+
+export function useShellSelection(): void {
+  const select = useUIStore((s) => s.select);
+  const setView = useUIStore((s) => s.setView);
+
+  useEffect(() => {
+    const bridge = window.__opentradeShell;
+    if (!bridge) return;
+    const apply = (agentId: string) => {
+      select(agentId);
+      setView("agents");
+    };
+    let alive = true;
+    bridge.takePendingAgent().then((id) => {
+      if (alive && id) apply(id);
+    });
+    const unsubscribe = bridge.onSelectAgent(apply);
+    return () => {
+      alive = false;
+      unsubscribe();
+    };
+  }, [select, setView]);
+}

--- a/app/src/renderer/screens/Settings.tsx
+++ b/app/src/renderer/screens/Settings.tsx
@@ -108,12 +108,27 @@ export function SettingsScreen() {
 }
 
 function GeneralPanel() {
+  const settings = useSettings();
   const update = useUpdateSettings();
   const setView = useUIStore((s) => s.setView);
+  const s = settings.data;
+  if (!s) return null;
 
   return (
     <div className="space-y-8">
-      <SettingsSection title="Setup" description="First-run onboarding.">
+      <SettingsSection
+        title="Menu bar"
+        description="Keep an eye on your agents from the macOS menu bar."
+      >
+        <SettingsRow label="Show OpenTrade in the menu bar">
+          <SettingToggle
+            checked={s.showInMenuBar}
+            onChange={(showInMenuBar) => update.mutate({ showInMenuBar })}
+          />
+        </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection title="Setup">
         <SettingsRow
           label="Re-run setup"
           hint="Reopen the onboarding wizard — agent CLI check, Robinhood, first agent."
@@ -129,6 +144,23 @@ function GeneralPanel() {
             Re-run setup
           </Button>
         </SettingsRow>
+        {/* Regular Quit keeps the background host (and any scheduled agents) running —
+            this is the way to actually stop everything. Launcher-owned, so it rides the
+            shell bridge (window.__opentradeShell), not tRPC; absent in a plain browser. */}
+        {window.__opentradeShell && (
+          <SettingsRow
+            label="Quit OpenTrade completely"
+            hint="Stops the OpenTrade host process. Agents will not run in the background until you reopen the app."
+          >
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void window.__opentradeShell?.quitCompletely()}
+            >
+              Quit completely
+            </Button>
+          </SettingsRow>
+        )}
       </SettingsSection>
 
       {/* Not a titled section: this is an informational heads-up about the underlying

--- a/app/src/shared/agent.ts
+++ b/app/src/shared/agent.ts
@@ -43,6 +43,11 @@ export const Agent = z.object({
   /** Whether the global headless turn limit (`AppSettings.maxHeadlessTurns`) applies
    *  to this agent. There is no per-agent limit VALUE — only this on/off switch. */
   turnLimitEnabled: z.boolean(),
+  /** Last time the AGENT did something (epoch ms) = `agents.last_turn_at`, stamped
+   *  by the Stop hook (both harnesses, interactive + background) and at wake fire
+   *  (agent messages only — a user message alone never moves it). Null until the
+   *  agent's first turn after the column shipped. Powers the tray sublabel (§12.6). */
+  lastActiveAt: z.number().nullable(),
   createdAt: z.number(),
   archivedAt: z.number().nullable(),
 });

--- a/app/src/shared/analytics.ts
+++ b/app/src/shared/analytics.ts
@@ -97,6 +97,7 @@ const settingKey = z.enum([
   "notifyApprovals",
   "notifyRestricted",
   "notifyUpdates",
+  "showInMenuBar",
 ]);
 
 /** Onboarding step ids (mirrors renderer/screens/Onboarding.tsx). */

--- a/app/src/shared/notify.ts
+++ b/app/src/shared/notify.ts
@@ -28,6 +28,16 @@ export interface HostNotification {
 }
 
 /**
+ * A notify-bus event as persisted in the host's `recent_notifications` ring buffer
+ * (§12.6) and served to the tray's Recent submenu over `notifications.onRecent`.
+ * `at` is stamped by the host at record time — keep it a plain epoch-ms number so
+ * the wire shape stays superjson-trivial.
+ */
+export interface RecentNotification extends HostNotification {
+  at: number;
+}
+
+/**
  * First non-empty line of a prompt, trimmed and truncated — the body of a wake
  * notification. Keeps a multi-line prompt from spilling into the banner.
  */

--- a/app/src/shared/settings.ts
+++ b/app/src/shared/settings.ts
@@ -54,6 +54,12 @@ export const AppSettings = z.object({
   notifyUpdates: z.boolean(),
   /** Agent ids whose notifications are muted entirely (a coarse per-agent switch). */
   notifyMutedAgents: z.array(z.string()),
+
+  // ---- menu bar (§12.6) ----
+  /** Show the OpenTrade status item in the macOS menu bar and keep the launcher alive
+   *  there when the window is closed / ⌘Q'd, so agent status + notifications keep
+   *  flowing while the app is "closed". On by default; off restores plain quit. */
+  showInMenuBar: z.boolean(),
 });
 export type AppSettings = z.infer<typeof AppSettings>;
 
@@ -74,6 +80,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   notifyRestricted: true,
   notifyUpdates: true,
   notifyMutedAgents: [],
+  showInMenuBar: true,
 };
 
 /** A partial update of the editable settings. */

--- a/app/src/shared/shell.ts
+++ b/app/src/shared/shell.ts
@@ -1,0 +1,22 @@
+/**
+ * Wire contract for the "shell" bridge between the Electron MAIN process and the
+ * renderer — main-process UI chrome that needs to steer the renderer. Today that
+ * is the macOS menu bar item (§12.6): clicking an agent in the tray menu opens the
+ * window *and* selects that agent. Like the updater bridge (`shared/updater.ts`),
+ * this is main-process state (the tray lives in the launcher, not the host), so it
+ * rides `ipcRenderer` rather than tRPC.
+ *
+ * Delivery is push + pull because the window may not exist yet when the click
+ * lands: main pushes `selectAgent` to a live renderer, and a freshly created
+ * renderer pulls any selection that was requested before it mounted.
+ */
+export const SHELL_IPC = {
+  /** main → renderer push: select this agent (and switch to the agents view). */
+  selectAgent: "shell:selectAgent",
+  /** invoke → the agent id requested before the renderer mounted (consumed on read), or null. */
+  takePendingAgent: "shell:takePendingAgent",
+  /** invoke → full quit: terminate the backend host, then exit the launcher (§12.6).
+   *  A launcher action (it owns the host pid + its own exit), so it rides this
+   *  bridge — the Settings button and the tray row share one main-process path. */
+  quitCompletely: "shell:quitCompletely",
+} as const;


### PR DESCRIPTION
Agents already run in a persistent background host with the app closed, but quitting also killed the only process that could show a notification — so "closed" meant flying blind. This adds a status item in the menu bar.

## Quit behaviour

⌘Q, dock-Quit and the red button now close the window and hide the dock icon instead of exiting; the launcher lives on as the menu bar item, still relaying notifications. Real exits are:

- the item's own **Quit OpenTrade**
- an app update's relaunch
- OS shutdown / restart / logout
- POSIX signals — so an external `kill` can't leave an orphaned item behind

A new **Show OpenTrade in the menu bar** setting (General, on by default) turns the whole behaviour off and restores a plain quit. So does a backend that failed to start, since its recovery is "quit and reopen".

## The menu

- **Open OpenTrade** first, where the cursor lands
- a row per agent: name, with status and last-active underneath
- a pending-approval line — the count also rides beside the menu bar icon, since the dock badge is gone once the window closes
- **Recent ▸**, the last ten notifications
- **Quit OpenTrade** — the launcher only; agents keep running
- **Quit OpenTrade Completely** — the backend host too: one SIGTERM tears the whole tree down gracefully (in-flight wakes killed with their spawn markers cleared so no agent reads as crashed, codex app-servers and PTYs stopped), then the launcher exits. The next launch respawns the host. A **Quit completely** button in Settings → General rides the same shell-bridge path

Clicking an agent opens the window *and* selects it, through a small main→renderer bridge alongside the existing updater one.

## Host-owned content

Two things must outlive the launcher, so the host owns them:

**Last active** is a single stamped column (`agents.last_turn_at`), written at turn end by both harnesses' Stop hooks — codex fires the same claude-shaped Stop event from its app-server, for TUI threads and background wakes alike — and at wake fire by the scheduler, so a run that dies mid-flight still leaves its start mark. It deliberately tracks the *agent* speaking, not the user typing.

**Recent** is a durable ring buffer holding only the rolling last ten (not a log — displaced rows are deleted). It's written from the raw notification stream, so muting a banner doesn't blind the monitor, and served over a subscription that emits the full list on connect — which makes it self-heal across relay reconnects and repopulate after a launcher or host restart. It's a whole new table, so it arrives via the DDL with no migration.

## Incidental fix

Window creation is consolidated into one path: a window recreated after close previously lost its focus→broker-cadence relay, and the approval stream could call `focus()` on a destroyed one.

## Verification

`bun run typecheck`, `bun run lint`, and `bun test` (305 pass) are green; `electron-vite build` succeeds. Behaviour verified live on macOS: the menu bar item appears, ⌘Q retreats to it with the dock icon hidden, and reopening restores both.

Sublabels are a native menu subtitle and need macOS 14.4+; below that a row shows just the agent name and Recent rows lose their timestamps. Noted in the follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

