### PR TITLE
Fix mobile hero scrolling

### DIFF
--- a/website/src/components/templates/creative-studio/hero.tsx
+++ b/website/src/components/templates/creative-studio/hero.tsx
@@ -1,8 +1,8 @@
 import { ArrowRight } from "lucide-react";
-import { motion, useReducedMotion, useScroll, useTransform } from "motion/react";
-import { useRef } from "react";
+import { motion, useReducedMotion } from "motion/react";
 
 import appWindow from "@/assets/app-window.jpg";
+import heroGradient from "@/assets/hero-gradient.jpg";
 import opentradeLogo from "@/assets/opentrade-logo-type-mono.svg";
 import { track } from "@/lib/analytics";
 
@@ -25,15 +25,7 @@ function GitHubMark({ className }: { className?: string }) {
   );
 }
 
-export function Hero({ videoSrc, posterSrc }: { videoSrc?: string; posterSrc?: string }) {
-  const reduce = useReducedMotion();
-  const heroRef = useRef<HTMLElement>(null);
-  const { scrollYProgress } = useScroll({
-    target: heroRef,
-    offset: ["start start", "end end"],
-  });
-  const mobileWindowY = useTransform(scrollYProgress, [0, 0.68, 1], ["0dvh", "-68dvh", "-72dvh"]);
-
+function HeroCopy({ reduce }: { reduce: boolean | null }) {
   const fade = (delay: number) => ({
     initial: reduce ? false : { y: 20, opacity: 0 },
     animate: { y: 0, opacity: 1 },
@@ -41,131 +33,183 @@ export function Hero({ videoSrc, posterSrc }: { videoSrc?: string; posterSrc?: s
   });
 
   return (
-    <section ref={heroRef} className="relative h-[140dvh] w-full bg-black p-4 sm:h-dvh md:p-6">
-      <div className="sticky top-4 flex h-[calc(100dvh-2rem)] w-full flex-col overflow-hidden rounded-2xl bg-black sm:relative sm:top-auto md:h-[calc(100dvh-3rem)] md:rounded-[2rem]">
-        {videoSrc ? (
-          <video
-            className="absolute inset-0 h-full w-full object-cover"
-            src={videoSrc}
-            poster={posterSrc}
-            autoPlay
-            loop
-            muted
-            playsInline
+    <div className="grid grid-cols-12 items-end gap-6 md:gap-8">
+      <div className="col-span-12 lg:col-span-8">
+        <h1 className="relative max-sm:-left-2 max-sm:top-2">
+          <motion.img
+            {...fade(0.25)}
+            src={opentradeLogo}
+            alt="OpenTrade"
+            width={451}
+            height={120}
+            className="h-auto w-[74vw] max-w-[48rem] md:w-[58vw] lg:w-[44vw] lg:max-w-[42rem]"
           />
-        ) : (
-          <CinematicBackground variant="hero" />
-        )}
+        </h1>
+      </div>
 
-        <NoiseOverlay className="opacity-[0.35] mix-blend-overlay" />
-
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/5 via-transparent to-black/20"
-        />
-
-        {/* Mobile: two scroll-linked crops reveal the left and right panels in sequence. */}
-        <motion.div
-          aria-hidden
-          className="absolute inset-x-0 top-[4dvh] z-[5] flex flex-col gap-[10dvh] sm:hidden"
-          style={{ y: mobileWindowY }}
+      <div className="col-span-12 flex flex-col gap-4 md:gap-6 lg:col-span-4 lg:items-end 2xl:pr-6">
+        <motion.p
+          {...fade(0.5)}
+          className="w-full max-w-md text-[clamp(0.875rem,1.1vw,1rem)] text-(--cs-ink)/70"
+          style={{ lineHeight: 1.3 }}
         >
+          An open-source trading harness for Claude Code and Codex agents. Agents can trade through
+          Robinhood&rsquo;s official MCP, run custom market-watch scripts, operate within enforced
+          guardrails, and run in the background &mdash; all on your machine.
+        </motion.p>
+
+        <motion.div {...fade(0.7)} className="flex w-full max-w-md flex-wrap items-center gap-3">
+          <a
+            href={DOWNLOAD_URL}
+            onClick={() => track("download_clicked")}
+            className="group inline-flex w-fit items-center gap-2 rounded-full bg-(--cs-ink) py-1.5 pe-1.5 ps-5 text-sm font-medium text-black transition-all duration-300 hover:gap-3 sm:text-base"
+          >
+            Download for macOS
+            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black transition-transform duration-300 group-hover:scale-110 sm:h-10 sm:w-10">
+              <ArrowRight className="h-4 w-4 text-(--cs-cream) rtl:rotate-180" />
+            </span>
+          </a>
+          <a
+            href="https://github.com/OpenTradeOSS/OpenTrade"
+            onClick={() => track("github_clicked")}
+            className="group inline-flex w-fit items-center gap-2 rounded-full bg-black py-1.5 pe-1.5 ps-5 text-sm font-medium text-(--cs-ink) transition-all duration-300 hover:gap-3 sm:text-base"
+          >
+            View on GitHub
+            <span className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 transition-transform duration-300 group-hover:scale-110 sm:h-10 sm:w-10">
+              <GitHubMark className="h-4 w-4 text-(--cs-ink)" />
+            </span>
+          </a>
+        </motion.div>
+      </div>
+    </div>
+  );
+}
+
+function Scrim({ className }: { className: string }) {
+  return (
+    <div
+      aria-hidden
+      className={className}
+      style={{
+        background: "linear-gradient(to top, #000 0%, #000 40%, rgb(0 0 0 / 0) 100%)",
+      }}
+    />
+  );
+}
+
+function MobileHero({ reduce }: { reduce: boolean | null }) {
+  return (
+    <section className="relative isolate bg-black sm:hidden">
+      {/* The dynamic viewport keeps the stage flush with Safari's currently visible bottom edge. */}
+      <div className="sticky top-0 h-dvh p-4">
+        <div className="relative h-full overflow-hidden rounded-2xl bg-black">
+          <div
+            className="absolute inset-0 bg-cover bg-center bg-no-repeat"
+            style={{ backgroundImage: `url(${heroGradient})` }}
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/5 via-transparent to-black/20"
+          />
+        </div>
+      </div>
+
+      {/* Foreground aperture: masks scrolling screenshots beneath the black viewport frame. */}
+      <div
+        aria-hidden
+        className="pointer-events-none fixed left-4 right-4 top-4 z-[6] h-[calc(100lvh-2rem)] rounded-2xl shadow-[0_0_0_100vmax_#000]"
+      />
+
+      {/* iOS 26 mispaints `position: fixed; bottom: 0`. Anchor from the top of the
+          large viewport instead; this is a static CSS transform with no scroll work. */}
+      <div
+        className="pointer-events-none fixed inset-x-4 top-0 z-10"
+        style={{ transform: "translateY(calc(100lvh - 100% - 1rem))" }}
+      >
+        <footer className="pointer-events-auto relative isolate overflow-hidden rounded-b-2xl px-4 pb-4 pt-24">
+          <Scrim className="pointer-events-none absolute inset-0 -z-10" />
+          <HeroCopy reduce={reduce} />
+        </footer>
+      </div>
+
+      {/* Both screenshots use normal document scrolling: no listeners or per-frame transforms. */}
+      <div className="relative z-[5] -mt-[100dvh] px-4">
+        <div className="flex flex-col gap-[10svh] overflow-x-hidden rounded-2xl pb-[25svh] pt-[4svh]">
           <img
             src={appWindow}
-            alt=""
+            alt="The OpenTrade app showing the agent sidebar and live coding terminal"
             width={2536}
             height={1482}
+            decoding="async"
+            fetchPriority="high"
             className="ml-[2%] h-auto w-[260%] max-w-none self-start rounded-lg shadow-[0_30px_100px_-20px_rgba(0,0,0,0.85)] ring-1 ring-white/10"
           />
           <img
             src={appWindow}
-            alt=""
+            alt="The OpenTrade app showing the portfolio and position performance panel"
             width={2536}
             height={1482}
+            decoding="async"
+            loading="lazy"
             className="mr-[2%] h-auto w-[260%] max-w-none self-end rounded-lg shadow-[0_30px_100px_-20px_rgba(0,0,0,0.85)] ring-1 ring-white/10"
           />
-        </motion.div>
-
-        {/* Tablet and desktop retain the original single centered window. */}
-        <motion.div
-          initial={reduce ? false : { y: 24, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{ duration: 1, delay: 0.25, ease: EASE_OUT_EXPO }}
-          className="absolute left-1/2 top-[42%] z-[5] hidden w-[84%] -translate-x-1/2 -translate-y-1/2 sm:block lg:w-[74%] xl:w-[72%] xl:max-w-[100rem]"
-        >
-          <img
-            src={appWindow}
-            alt="The OpenTrade app: agent sidebar, the selected agent's live Claude Code terminal, and its portfolio panel"
-            width={2536}
-            height={1482}
-            className="h-auto w-full origin-top scale-[1.08] rounded-lg shadow-[0_30px_100px_-20px_rgba(0,0,0,0.85)] ring-1 ring-white/10 lg:rounded-xl"
-          />
-        </motion.div>
-
-        <div className="relative z-10 mt-auto p-4 sm:p-6 md:p-8 lg:p-10">
-          {/* Legibility scrim: black at the bottom edge → transparent just above the text block. */}
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 -top-[45%] bottom-0 -z-10"
-            style={{
-              background:
-                "linear-gradient(to top, rgb(0 0 0) 0%, rgb(0 0 0) 40%, rgb(0 0 0 / 0) 100%)",
-            }}
-          />
-          <div className="grid grid-cols-12 items-end gap-6 md:gap-8">
-            <div className="col-span-12 lg:col-span-8">
-              <h1 className="relative max-sm:-left-2 max-sm:top-2">
-                <motion.img
-                  {...fade(0.25)}
-                  src={opentradeLogo}
-                  alt="OpenTrade"
-                  width={451}
-                  height={120}
-                  className="h-auto w-[74vw] max-w-[48rem] md:w-[58vw] lg:w-[46vw] lg:max-w-[44rem]"
-                />
-              </h1>
-            </div>
-
-            <div className="col-span-12 flex flex-col gap-4 md:gap-6 lg:col-span-4 lg:items-end 2xl:pr-6">
-              <motion.p
-                {...fade(0.5)}
-                className="w-full max-w-md text-[clamp(0.875rem,1.1vw,1rem)] text-(--cs-ink)/70"
-                style={{ lineHeight: 1.3 }}
-              >
-                An open-source trading harness for Claude Code and Codex agents. Agents can trade
-                through Robinhood&rsquo;s official MCP, run custom market-watch scripts, operate
-                within enforced guardrails, and run in the background &mdash; all on your machine.
-              </motion.p>
-
-              <motion.div
-                {...fade(0.7)}
-                className="flex w-full max-w-md flex-wrap items-center gap-3"
-              >
-                <a
-                  href={DOWNLOAD_URL}
-                  onClick={() => track("download_clicked")}
-                  className="group inline-flex w-fit items-center gap-2 rounded-full bg-(--cs-ink) py-1.5 pe-1.5 ps-5 text-sm font-medium text-black transition-all duration-300 hover:gap-3 sm:text-base"
-                >
-                  Download for macOS
-                  <span className="flex h-9 w-9 items-center justify-center rounded-full bg-black transition-transform duration-300 group-hover:scale-110 sm:h-10 sm:w-10">
-                    <ArrowRight className="h-4 w-4 text-(--cs-cream) rtl:rotate-180" />
-                  </span>
-                </a>
-                <a
-                  href="https://github.com/OpenTradeOSS/OpenTrade"
-                  onClick={() => track("github_clicked")}
-                  className="group inline-flex w-fit items-center gap-2 rounded-full bg-black py-1.5 pe-1.5 ps-5 text-sm font-medium text-(--cs-ink) transition-all duration-300 hover:gap-3 sm:text-base"
-                >
-                  View on GitHub
-                  <span className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 transition-transform duration-300 group-hover:scale-110 sm:h-10 sm:w-10">
-                    <GitHubMark className="h-4 w-4 text-(--cs-ink)" />
-                  </span>
-                </a>
-              </motion.div>
-            </div>
-          </div>
         </div>
       </div>
     </section>
+  );
+}
+
+export function Hero({ videoSrc, posterSrc }: { videoSrc?: string; posterSrc?: string }) {
+  const reduce = useReducedMotion();
+
+  return (
+    <>
+      <MobileHero reduce={reduce} />
+
+      <section className="relative hidden h-svh w-full bg-black p-4 sm:block md:p-6">
+        <div className="relative flex h-[calc(100svh-2rem)] w-full flex-col overflow-hidden rounded-2xl bg-black md:h-[calc(100svh-3rem)] md:rounded-[2rem]">
+          {videoSrc ? (
+            <video
+              className="absolute inset-0 h-full w-full object-cover"
+              src={videoSrc}
+              poster={posterSrc}
+              autoPlay
+              loop
+              muted
+              playsInline
+            />
+          ) : (
+            <CinematicBackground variant="hero" />
+          )}
+
+          <NoiseOverlay className="opacity-[0.35] mix-blend-overlay" />
+
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/5 via-transparent to-black/20"
+          />
+
+          <motion.div
+            initial={reduce ? false : { y: 24, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 1, delay: 0.25, ease: EASE_OUT_EXPO }}
+            className="absolute left-1/2 top-[42%] z-[5] w-[84%] -translate-x-1/2 -translate-y-1/2 lg:w-[74%] xl:w-[72%] xl:max-w-[100rem]"
+          >
+            <img
+              src={appWindow}
+              alt="The OpenTrade app: agent sidebar, the selected agent's live Claude Code terminal, and its portfolio panel"
+              width={2536}
+              height={1482}
+              className="h-auto w-full origin-top scale-[1.08] rounded-lg shadow-[0_30px_100px_-20px_rgba(0,0,0,0.85)] ring-1 ring-white/10 lg:rounded-xl"
+            />
+          </motion.div>
+
+          <div className="relative z-10 mt-auto p-4 sm:p-6 md:p-8 lg:p-10">
+            <Scrim className="pointer-events-none absolute inset-x-0 -top-[45%] bottom-0 -z-10" />
+            <HeroCopy reduce={reduce} />
+          </div>
+        </div>
+      </section>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- replace mobile scroll-linked transforms with native document scrolling
- keep the static gradient and two side-cropped app-window views
- anchor the mobile hero footer with a CSS-only iOS 26 viewport workaround
- preserve the existing desktop hero presentation

## Testing
- bun run build
- verified smooth scrolling and footer placement on a physical iPhone