### PR TITLE
[posthog-monitor] Telemetry: carry error_code on updater app_errors

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import type { Agent } from "@shared/agent";
-import { errorNameOf, sanitizeStack } from "@shared/analytics";
+import { errorCodeOf, errorNameOf, sanitizeStack } from "@shared/analytics";
 import type { HostNotification, NotificationKind, RecentNotification } from "@shared/notify";
 import { type AppSettings, DEFAULT_SETTINGS } from "@shared/settings";
 import { SHELL_IPC } from "@shared/shell";
@@ -285,12 +285,18 @@ async function main() {
         quitting = false;
       }
       const frames = sanitizeStack(err);
+      // electron-updater reports check/download failures as a bare `Error`, so the class
+      // name says nothing and a network throw often leaves no frame of ours. `err.code`
+      // (or its `cause`'s, for an undici `fetch failed`) is the only token that separates
+      // "this machine can't reach the feed" from a server-side or signing failure.
+      const code = errorCodeOf(err);
       relayTrpc?.analytics.track
         .mutate({
           event: "app_error",
           props: {
             subsystem: "updater",
             error_name: errorNameOf(err),
+            ...(code ? { error_code: code } : {}),
             source: "caught",
             ...(frames.length ? { frames } : {}),
           },

--- a/app/src/main/services/analytics/analytics.test.ts
+++ b/app/src/main/services/analytics/analytics.test.ts
@@ -407,6 +407,33 @@ describe("analytics allowlist + normalizers", () => {
     ).toBe(true);
   });
 
+  test("RendererTrackInput carries a bounded error_code but not a message", () => {
+    // The updater relay's reason for existing: a bare `Error` plus its machine code.
+    expect(
+      RendererTrackInput.safeParse({
+        event: "app_error",
+        props: {
+          subsystem: "updater",
+          error_name: "Error",
+          error_code: "ENOTFOUND",
+          source: "caught",
+        },
+      }).success,
+    ).toBe(true);
+    // A `code` holding free text fails the same regex the host path uses, so the tRPC
+    // surface can't be used to smuggle a message through the field.
+    expect(
+      RendererTrackInput.safeParse({
+        event: "app_error",
+        props: {
+          subsystem: "updater",
+          error_name: "Error",
+          error_code: "Cannot parse releases feed: /Users/a/Library",
+        },
+      }).success,
+    ).toBe(false);
+  });
+
   test("sanitizeStack keeps bundle + dependency frames, drops node internals", () => {
     const err = new Error("boom");
     err.stack = [

--- a/app/src/shared/analytics.ts
+++ b/app/src/shared/analytics.ts
@@ -244,6 +244,11 @@ export const RendererTrackInput = z.discriminatedUnion("event", [
     props: z.strictObject({
       subsystem: z.enum(["renderer", "updater"]),
       error_name: errorName,
+      // Same bounded token as the host path (see `errorCode`). The updater's failures
+      // arrive as a bare `Error` from electron-updater — no useful class name and, when
+      // the throw is a network failure, often no frames of ours either — so without the
+      // code a failed update check is indistinguishable from any other.
+      error_code: errorCode.optional(),
       source: ErrorSource.optional(),
       frames: frames.optional(),
     }),


### PR DESCRIPTION
## Evidence

23 `app_error` events with `subsystem: "updater"` over the last 14 days — 0.2.3 ×1, 0.2.4 ×2, 0.2.5 ×20 — every single one `error_name: "Error"`, `source: "caught"`, **no `error_code`, no `frames`**. The event records that the updater failed and nothing else.

On the current release they land on a clean ~4h grid (03:47, 23:45, 19:40, 15:28, 11:22, 07:19, 03:17, …), i.e. `CHECK_INTERVAL_MS` in `app/src/main/updater.ts:32` firing 6×/day. Per-day counts since that install moved to 0.2.5: 1, 5, 7, 6. Six scheduled checks a day, five-to-seven failures a day — effectively the whole schedule.

All of it comes from the one 0.2.5 install with a session long enough to reach a 4h tick (97h span, a single `host_started`). The other four 0.2.5 installs in the same period ran under an hour each and never hit the timer — so this is closer to 1-of-1 eligible than 1-of-many.

Ruled out: the missing-feed case `updater.ts:141` special-cases. The v0.2.5 release has `latest-mac.yml` published (511 B, 142 downloads), so the feed exists and is being fetched.

Impact today is nil — 0.2.5 *is* the latest release, so a failing check has nothing to find. The moment 0.2.6 ships, that install most likely never sees it, which is exactly the silent-failure case the header comment in `updater.ts` says this telemetry exists to surface.

## Root cause of the blind spot

Two things on the updater path, neither of which is the update failure itself:

- `app/src/shared/analytics.ts:243` — `RendererTrackInput`'s `app_error` variant omits `error_code` entirely. `TELEMETRY_EVENTS.app_error` has always allowed the field, but the updater relays over the tRPC surface (it runs in the Electron main process, not the host), so nothing on this path could populate it even if the caller tried.
- `app/src/main/index.ts:276` — `initAutoUpdate`'s `onError` hand-builds its props and never calls `errorCodeOf`, unlike `AnalyticsService.trackError` (`app/src/main/services/analytics/index.ts:176`) which has done so for host-side errors since #10.

Together: an electron-updater failure arrives as a bare `Error` (class name says nothing), a network throw leaves no frame of ours (`sanitizeStack` returns empty), and the one field that would disambiguate is structurally unreachable.

## The change

- Widen `RendererTrackInput`'s `app_error` props with `error_code: errorCode.optional()` — the same bounded token the host path uses.
- Call `errorCodeOf(err)` at the updater relay site and include it when present.
- One new test in `app/src/main/services/analytics/analytics.test.ts`: a valid `ENOTFOUND` parses on the updater variant, and an `error_code` holding free text (`"Cannot parse releases feed: /Users/a/Library"`) is rejected — so the widened surface can't be used to smuggle a message or path through the new field.

39 insertions across 3 files.

## Allowlist invariants

Unchanged. `errorCode` is the existing `/^[A-Za-z0-9_]{1,48}$/` regex, validated in the same place, and `errorCodeOf` only returns a value that *already* fits that shape — nothing is coerced or truncated into one. The props object stays `z.strictObject`, and the host re-validates through `TELEMETRY_EVENTS` regardless of what the relay sends. No free-form string is introduced.

## Verification

- `bun install --frozen-lockfile` — clean.
- `bun run typecheck` — clean.
- `bunx @biomejs/biome check` on the three changed files — clean.
- `bun test` from `app/`: **301 pass / 7 fail** with this change vs **300 pass / 7 fail** on the same base without it. The +1 is the new test; the 7 failures (agent CLAUDE.md composition, Codex app-server WebSocket) are identical with the change stashed and are unrelated to this diff.

Two pre-existing issues noticed while verifying, both untouched here and worth a separate look:
- `bun test` from the repo root — which is what the root `package.json` `test` script runs — fails 16 tests / 9 errors with `Cannot find module '@shared/*'`. The alias lives in `app/tsconfig.json` and Bun does not search upward; run from `app/` it resolves. Identical on a clean tree.
- Repo-wide `bun run lint` reports 3 errors / 21 warnings on a clean tree.

## Risk

Low, and additive. Older builds simply keep sending no `error_code`. The only behavioural change is one extra optional field on updater `app_error` events; a code that fails the regex is dropped by `errorCodeOf` before it reaches the event, so it can't cost us the whole event.

---
_Generated by [Claude Code](https://claude.ai/code/session_0128hXeESThVH1BrjUp2MbUP)_