### PR TITLE
[posthog-monitor] Telemetry: report when the consent browser actually opens

### DIFF
--- a/app/src/main/services/broker/robinhood/oauth.test.ts
+++ b/app/src/main/services/broker/robinhood/oauth.test.ts
@@ -1,8 +1,9 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import type { Db } from "../../../db/client";
 import * as schema from "../../../db/schema";
+import { analytics } from "../../analytics";
 import { BrokerOAuthProvider, ConsentRequired } from "./oauth";
 
 function memDb(): Db {
@@ -10,6 +11,17 @@ function memDb(): Db {
   sqlite.exec("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
   return drizzle(sqlite, { schema }) as unknown as Db;
 }
+
+// Spy on the singleton rather than starting it with a fake client: `start` is idempotent,
+// so in a full-suite run whichever file starts it first owns it and a second fake client
+// would silently receive nothing. The spy asserts the call this file is about.
+let tracked: ReturnType<typeof spyOn<typeof analytics, "track">>;
+beforeEach(() => {
+  tracked = spyOn(analytics, "track").mockImplementation(() => {});
+});
+afterEach(() => {
+  tracked.mockRestore();
+});
 
 function provider() {
   const opened: string[] = [];
@@ -59,5 +71,30 @@ describe("BrokerOAuthProvider", () => {
     p.endAuthorization();
     expect(() => p.redirectToAuthorization(new URL("https://x"))).toThrow(ConsentRequired);
     expect(opened).toHaveLength(1);
+  });
+
+  test("opening the browser reports broker_consent_opened with the budget already spent", () => {
+    const { p, opened } = provider();
+    p.beginAuthorization("http://127.0.0.1:50123/callback");
+    p.redirectToAuthorization(new URL("https://robinhood.com/oauth"));
+
+    expect(opened).toHaveLength(1);
+    const calls = tracked.mock.calls.filter(([event]) => event === "broker_consent_opened");
+    expect(calls).toHaveLength(1);
+    // How much of the consent timeout was gone before the user could act. Bounded by the
+    // test's own runtime, so assert the shape the allowlist requires, not a value.
+    const armed = (calls[0][1] as { armed_ms: number }).armed_ms;
+    expect(Number.isInteger(armed)).toBe(true);
+    expect(armed).toBeGreaterThanOrEqual(0);
+  });
+
+  test("a browser that never opened reports nothing — that's the case the event separates", () => {
+    const { p } = provider();
+    // Silent connect: the gate throws before `openBrowser`, so an OAUTH_TIMEOUT with no
+    // `broker_consent_opened` means the user was never shown a page.
+    expect(() => p.redirectToAuthorization(new URL("https://robinhood.com/oauth"))).toThrow(
+      ConsentRequired,
+    );
+    expect(tracked.mock.calls.filter(([e]) => e === "broker_consent_opened")).toHaveLength(0);
   });
 });

--- a/app/src/main/services/broker/robinhood/oauth.ts
+++ b/app/src/main/services/broker/robinhood/oauth.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import type { Db } from "../../../db/client";
 import { settings } from "../../../db/schema";
+import { analytics } from "../../analytics";
 
 /**
  * Read/write the settings kv. Values are stored as plaintext JSON: the backend
@@ -110,6 +111,12 @@ export class BrokerOAuthProvider {
    * as the browser gate: the SDK may only open a browser while this is set.
    */
   private activeRedirectUrl: string | null = null;
+  /**
+   * When the current consent's loopback was bound — which is also when its timeout
+   * started running. Used only to measure how much of that budget was gone by the time
+   * the browser opened (`broker_consent_opened`).
+   */
+  private armedAt: number | null = null;
 
   constructor(private opts: OAuthProviderOptions) {
     this.store = new SecureStore(opts.db);
@@ -140,11 +147,13 @@ export class BrokerOAuthProvider {
     this.store.clear(K_CLIENT);
     this.store.clear(K_VERIFIER);
     this.activeRedirectUrl = redirectUrl;
+    this.armedAt = Date.now();
   }
 
   /** The interactive consent ended (however it ended): the browser gate closes again. */
   endAuthorization() {
     this.activeRedirectUrl = null;
+    this.armedAt = null;
   }
 
   state() {
@@ -176,6 +185,10 @@ export class BrokerOAuthProvider {
   redirectToAuthorization(url: URL) {
     if (!this.activeRedirectUrl) throw new ConsentRequired();
     this.opts.openBrowser(url.toString());
+    // After the open, so a browser we failed to launch isn't recorded as one the user saw.
+    analytics.track("broker_consent_opened", {
+      armed_ms: this.armedAt === null ? 0 : Math.max(0, Date.now() - this.armedAt),
+    });
   }
 
   saveCodeVerifier(verifier: string) {

--- a/app/src/shared/analytics.ts
+++ b/app/src/shared/analytics.ts
@@ -160,6 +160,15 @@ export const TELEMETRY_EVENTS = {
    *  is attempts with no outcome event: superseded by a later click, still pending, or a
    *  silent connect that found a dead grant and quietly stayed disconnected. */
   broker_connect_started: z.strictObject({ mode: z.enum(["interactive", "silent"]) }),
+  /**
+   * The consent browser actually opened. Splits the two ways an interactive connect
+   * ends in `OAUTH_TIMEOUT`: the user saw the page and walked away (this event, then
+   * the timeout), or never got one at all (the timeout with no such event).
+   * `armed_ms` is the slice of the consent budget already spent when the browser
+   * opened — the loopback's timer starts at bind, before the SDK registers the client
+   * and opens the page, so a slow round-trip eats the user's window.
+   */
+  broker_consent_opened: z.strictObject({ armed_ms: z.number().int().nonnegative() }),
   broker_connected: z.strictObject({}),
   broker_connect_failed: z.strictObject({
     error_name: errorName,


### PR DESCRIPTION
## Evidence

Over the last 21 days, six installs hit `broker_connect_failed` with `error_code: "OAUTH_TIMEOUT"` — each exactly once, six different installs. Outcomes:

| | installs |
|---|---|
| hit `OAUTH_TIMEOUT`, later reached `broker_connected` | 2 |
| hit it, never produced a `broker_connected` | **4** |

Two of those four emitted nothing at all after ~15 minutes from first launch (6 and 8 lifetime events respectively) — a fresh install, one connect attempt, gone. That is a drop-off at the broker-connect step, but the telemetry cannot say which kind.

One of them also showed `broker_connect_started` → `broker_connect_failed` **16m34s** apart against a 10-minute budget, which means the timeout had already fired and its rejection sat unobserved while `doConnect()` was still in flight.

## What can't be answered today

`OAUTH_TIMEOUT` is ours, not Robinhood's: `openLoopback` arms a `CONSENT_TIMEOUT_MS` = 10-minute timer (`app/src/main/services/broker/robinhood/client.ts:26,140`) and rejects the pending consent if no callback arrives. Two very different situations produce the identical event:

1. The user saw the consent page and abandoned it → a copy/flow problem.
2. The user never got a usable page → a defect.

Nothing distinguishes them, so neither can be acted on.

There is also a concrete reason to suspect (2). The timer arms at **loopback bind** (`client.ts:140`), which happens *before* `beginAuthorization`, before the SDK registers the client, and before the browser opens (`client.ts:259-264`). Whatever that round-trip costs is deducted from the user's consent window, and nothing measures it.

## The change

Adds one allowlisted event, `broker_consent_opened`, emitted from `BrokerOAuthProvider.redirectToAuthorization` (`oauth.ts`) — the single point where the consent browser is actually launched:

- Emitted **after** `openBrowser`, so a launch that throws isn't recorded as a page the user saw.
- A silent connect throws `ConsentRequired` at the browser gate before `openBrowser`, so it reports nothing — by construction.
- `armed_ms`: milliseconds from loopback bind to browser open. The provider stamps the time in `beginAuthorization` (called immediately after the bind) and reports the delta at open; cleared in `endAuthorization`.

That gives the funnel two readings it doesn't have:
- `OAUTH_TIMEOUT` **with** a preceding `broker_consent_opened` → the user saw the page and walked away.
- `OAUTH_TIMEOUT` **without** one → the user never got a page.
- A routinely large `armed_ms` → the deadline is armed in the wrong place and should start at browser-open; a small one → the timeout is doing its job and the drop-off is behavioural.

## Allowlist invariants

Held. One `z.strictObject` whose only prop is a non-negative integer duration — no free-form string, no identifier, nothing about the account or the authorization URL (the `URL` argument is never read into the event). Unknown props still drop the whole event, and an out-of-shape `armed_ms` would fail validation rather than leak.

## Verification

- `bun install --frozen-lockfile` — clean.
- `bun run typecheck` — clean.
- `bunx @biomejs/biome check` on the three changed files — clean.
- `bun test` from `app/`: **303 pass / 7 fail** with this change vs **301 pass / 7 fail** on the same base without it. The +2 are the new tests; the 7 failures (agent CLAUDE.md composition, Codex app-server WebSocket) are identical with the change stashed and unrelated to this diff.

Two tests added to `oauth.test.ts`: opening the browser reports the event once with an integer, non-negative `armed_ms`; the gate-throw path reports nothing. They assert via `spyOn(analytics, "track")` rather than starting the singleton with a fake client — `AnalyticsService.start` is idempotent (`analytics/index.ts:105`), so in a full-suite run whichever file starts it first owns it and a second fake client would silently receive nothing. That is exactly how the first draft of this test passed alone and failed in the suite.

## Risk

Low, and additive. One new event on a path that only runs during interactive consent; no behaviour changes, and `openBrowser` is still called exactly as before. Worst case the event is emitted and nobody looks at it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0128hXeESThVH1BrjUp2MbUP)_