### PR TITLE
terminal: end the auto-respawn/reattach cascade causally

### DIFF
--- a/app/src/main/services/terminal/index.ts
+++ b/app/src/main/services/terminal/index.ts
@@ -15,6 +15,7 @@ import { TerminalManager } from "./manager";
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 const IDLE_AFTER_MS = 1500;
+
 /**
  * A `claude --resume` launch that exits within this window almost always means
  * there was no resumable conversation (the user killed/exited the prior session),
@@ -97,7 +98,7 @@ export class TerminalService {
     agent: Agent,
     cols = DEFAULT_COLS,
     rows = DEFAULT_ROWS,
-    intent: "auto" | "resume" = "auto",
+    intent: "auto" | "resume" | "attach" = "auto",
   ): Promise<{ alive: boolean; state: ExecutionState }> {
     const state = this.registry.executionStateOf(agent.id);
     // I1 single-writer: never spawn an interactive PTY alongside a headless run
@@ -107,6 +108,11 @@ export class TerminalService {
     // The GUI is interacting again — clear the teardown guard.
     this.guiGone = false;
     if (!this.manager.isLive(agent.id)) {
+      // `attach` never spawns: it's the post-respawn reconnect, whose contract is
+      // "the PTY is already alive". If it died in the meantime, spawning here would
+      // relaunch the stored id as a resume and re-arm the respawn guard — the exact
+      // reattach leg of the cascade. Report dead; the pane offers Resume.
+      if (intent === "attach") return { alive: false, state };
       // Coalesce concurrent opens onto ONE spawn (B7): a second call arriving during
       // the multi-second async spawn awaits the same promise instead of re-running it.
       let inflight = this.opening.get(agent.id);
@@ -232,20 +238,31 @@ export class TerminalService {
 
   /**
    * If a resumed launch died almost immediately, there was no conversation to
-   * resume — respawn a fresh session and tell the renderer to reattach. A fresh
-   * launch (`continued:false`) that dies is left alone, so we never loop. Returns
-   * whether a respawn was undertaken (the exit handler keeps the lock held if so);
-   * the spawn itself is async (codex mints its session server-side) and reports
-   * `onInteractiveDown` if it ultimately fails, so nothing is stranded.
+   * resume — respawn a fresh session and tell the renderer to reattach. Loop
+   * safety is causal: a fresh launch (`continued:false`) that dies is left
+   * alone, and the renderer's post-respawn reconnect is attach-only (it cannot
+   * relaunch the stored id as a resume), so a harness that exits on launch
+   * can't ping-pong between our respawn and the reattach.
+   * Returns whether a respawn was undertaken (the exit handler keeps the lock held
+   * if so); the spawn itself is async (codex mints its session server-side) and
+   * reports `onInteractiveDown` if it ultimately fails, so nothing is stranded.
    */
   private maybeRespawnFresh(agentId: string): boolean {
     const launch = this.launches.get(agentId);
+    // A fresh launch that dies is left alone — respawning it would just repeat it.
     if (!launch || !launch.continued) return false;
+    // It stayed up long enough to be a real session, not a dead `--resume`.
     if (Date.now() - launch.at > RESPAWN_GUARD_MS) return false;
+    // A user-driven open is already spawning: let it bring the session up rather
+    // than racing it with a second, uncoalesced spawn (double onInteractiveUp,
+    // `launches` describing the wrong PTY).
+    if (this.opening.has(agentId)) return false;
 
     const agent = this.registry.get(agentId);
     if (!agent || agent.archivedAt !== null) return false;
-    this.spawn(agent, "fresh", DEFAULT_COLS, DEFAULT_ROWS)
+    // Register in `opening` so a concurrent openOrAttach (pane remount during the
+    // multi-second codex spawn) awaits THIS spawn instead of starting its own (B7).
+    const inflight = this.spawn(agent, "fresh", DEFAULT_COLS, DEFAULT_ROWS)
       .then(() => {
         // The GUI may have gone away DURING this async respawn (codex spawn takes
         // seconds); teardown already ran and won't see this PTY, so kill it now rather
@@ -260,7 +277,9 @@ export class TerminalService {
       .catch((err) => {
         console.error("[terminal] auto-respawn failed", err);
         this.wake.onInteractiveDown(agentId); // the writer is gone after all
-      });
+      })
+      .finally(() => this.opening.delete(agentId));
+    this.opening.set(agentId, inflight);
     return true;
   }
 

--- a/app/src/main/trpc/routers/terminal.ts
+++ b/app/src/main/trpc/routers/terminal.ts
@@ -11,7 +11,9 @@ export const terminalRouter = router({
         agentId: z.string(),
         cols: z.number().optional(),
         rows: z.number().optional(),
-        intent: z.enum(["auto", "resume"]).default("auto"),
+        // `attach` never spawns — the post-respawn reconnect, which must not
+        // relaunch a dead session as a resume (that re-armed the respawn loop).
+        intent: z.enum(["auto", "resume", "attach"]).default("auto"),
       }),
     )
     .mutation(async ({ ctx, input }) => {

--- a/app/src/renderer/lib/terminal/session-controller.ts
+++ b/app/src/renderer/lib/terminal/session-controller.ts
@@ -65,11 +65,14 @@ class SessionController {
   /**
    * Reattach the focused agent after the host transparently respawned its
    * session (auto-respawn). The PTY is already alive, so a plain attach picks
-   * up the fresh stream + replay. Ignored if a different agent is now focused.
+   * up the fresh stream + replay — and `attach` guarantees exactly that: if the
+   * respawned PTY has ALREADY died, the host reports dead instead of spawning
+   * yet another launch (which resumed the stored id and looped the respawn).
+   * Ignored if a different agent is now focused.
    */
   reconnect(agentId: string) {
     if (this.currentAgentId !== agentId) return;
-    this.startSession(agentId, "auto");
+    this.startSession(agentId, "attach");
   }
 
   /** Stop showing any agent (e.g. selection cleared). PTYs keep running. */
@@ -80,7 +83,7 @@ class SessionController {
     this.teardownTransport();
   }
 
-  private startSession(agentId: string, intent: "auto" | "resume") {
+  private startSession(agentId: string, intent: "auto" | "resume" | "attach") {
     const myEpoch = ++this.epoch;
     this.currentAgentId = agentId;
     this.clearReconnect();
@@ -90,7 +93,7 @@ class SessionController {
     void this.connect(agentId, myEpoch, intent);
   }
 
-  private async connect(agentId: string, myEpoch: number, intent: "auto" | "resume" = "auto") {
+  private async connect(agentId: string, myEpoch: number, intent: "auto" | "resume" | "attach") {
     if (myEpoch !== this.epoch) return;
     this.setLiveness(agentId, "connecting");
     try {
@@ -107,18 +110,31 @@ class SessionController {
       const cols = this.runtime?.terminal.cols;
       const rows = this.runtime?.terminal.rows;
       // tRPC-first: ensure the session exists before opening the data socket.
-      await client.terminal.openOrAttach.mutate({ agentId, cols, rows, intent });
+      const { alive } = await client.terminal.openOrAttach.mutate({ agentId, cols, rows, intent });
       if (myEpoch !== this.epoch) return;
+      // An `attach` found no live PTY (the respawned session died before we got
+      // here). `startSession` reset the screen, so repaint the end-state banner
+      // rather than connecting a socket to nothing.
+      if (!alive && intent === "attach") {
+        this.setLiveness(agentId, "dead");
+        this.runtime?.terminal.write("\r\n\x1b[2m[session ended — Resume to continue]\x1b[0m\r\n");
+        return;
+      }
       const { url } = await client.terminal.wsEndpoint.query({ agentId });
       if (myEpoch !== this.epoch) return;
-      this.openSocket(agentId, url, myEpoch);
+      this.openSocket(agentId, url, myEpoch, intent);
     } catch {
       if (myEpoch !== this.epoch) return;
-      this.scheduleReconnect(agentId, myEpoch);
+      this.scheduleReconnect(agentId, myEpoch, intent);
     }
   }
 
-  private openSocket(agentId: string, url: string, myEpoch: number) {
+  private openSocket(
+    agentId: string,
+    url: string,
+    myEpoch: number,
+    intent: "auto" | "resume" | "attach",
+  ) {
     const runtime = this.runtime;
     if (!runtime) return;
     this.transport = connectTerminalWs(url, {
@@ -141,12 +157,17 @@ class SessionController {
       onClose: (code) => {
         if (myEpoch !== this.epoch) return;
         this.transport = null;
-        this.handleClose(agentId, code, myEpoch);
+        this.handleClose(agentId, code, myEpoch, intent);
       },
     });
   }
 
-  private handleClose(agentId: string, code: number, myEpoch: number) {
+  private handleClose(
+    agentId: string,
+    code: number,
+    myEpoch: number,
+    intent: "auto" | "resume" | "attach",
+  ) {
     // 1000: clean close right after an exit frame — onExit already marked dead.
     if (code === 1000) return;
     // Session gone on the host (daemon restarted): dead, Resume re-establishes.
@@ -156,10 +177,17 @@ class SessionController {
     }
     // 4408 (backpressure valve) or 1006 (abnormal, e.g. daemon crash): the
     // session likely still lives — reconnect with replay to catch up / recover.
-    this.scheduleReconnect(agentId, myEpoch);
+    this.scheduleReconnect(agentId, myEpoch, intent);
   }
 
-  private scheduleReconnect(agentId: string, myEpoch: number) {
+  /** Retries carry the ORIGINAL intent: an `attach` lineage must stay spawn-less
+   *  across transient failures, or a retry would relaunch the dead session as a
+   *  resume — the reattach leg of the respawn cascade, reopened by a hiccup. */
+  private scheduleReconnect(
+    agentId: string,
+    myEpoch: number,
+    intent: "auto" | "resume" | "attach",
+  ) {
     if (myEpoch !== this.epoch) return;
     if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
       this.setLiveness(agentId, "dead");
@@ -169,7 +197,7 @@ class SessionController {
     this.reconnectAttempts++;
     this.setLiveness(agentId, "connecting");
     this.reconnectTimer = setTimeout(() => {
-      if (myEpoch === this.epoch) void this.connect(agentId, myEpoch);
+      if (myEpoch === this.epoch) void this.connect(agentId, myEpoch, intent);
     }, delay);
   }
 


### PR DESCRIPTION
## The bug

A resumed interactive session that dies within seconds means there was no conversation to resume ("no conversation to continue"), and the host transparently respawns a fresh one (`maybeRespawnFresh`), guarded by `continued:false` so the fresh launch's own death is left alone. That guard didn't survive a round trip through the renderer: the post-respawn reconnect assumed "the PTY is already alive, so a plain attach picks up the fresh stream" — but when the harness also exited on the fresh launch, the reconnect found no live session and relaunched the stored id as a **resume** (`continued:true`), whose instant death re-qualified for the respawn. The two sides ping-ponged, spawning a process every ~200ms until a launch happened to stick.

Telemetry confirms the exact interleave on 0.2.3–0.2.5 (multiple installs, bursts typically starting right at app open): `terminal_respawned` + `terminal_session_started{fresh}`, then ~10–200ms later `terminal_session_started{resume}`, repeating — the largest burst ran 11 respawns in 3.1s.

## The change

Close the renderer leg of the loop, with no added state (3 files, +71/−22):

- **The post-respawn reconnect can no longer spawn.** It sends the new `openOrAttach` intent `attach`: attach when the respawned PTY is alive, otherwise report dead — the pane paints the session-ended banner with the Resume button instead of relaunching the stored id. Renderer retries carry the lineage's original intent through `scheduleReconnect`, so an attach lineage stays spawn-less across transient tRPC/WS failures too.
- **The respawn's spawn coalesces with user-driven opens.** It registers in the existing `opening` map, so a concurrent `openOrAttach` during the multi-second async spawn awaits it instead of racing a second spawn (double `onInteractiveUp`, launch tracking describing the wrong PTY), and a respawn is skipped when an open is already in flight.

With those two, a harness that exits on every launch gets exactly one automatic respawn per user-driven open, and the chain terminates in a dead pane with the Resume affordance — regardless of spawn latency, with no timer state to leak across kills, restarts, or GUI teardowns.

Earlier revisions bounded the loop with a 10s respawn cooldown (rate-limits the cascade rather than ending it — a single sanctioned spawn wait can outlast any cooldown sized near the 8s guard — and its suppression state leaked across teardown), then with discarding freshly minted session ids on early death (risked orphaning valid history and replaying the kickoff, since uptime alone doesn't prove a session never became a conversation). Both were dropped in favor of the attach-only reconnect, which is sufficient on its own.

The invariants ("attach never spawns", retries keep their intent, concurrent opens share one spawn) live at the service/controller boundary, which has no test seam today (`TerminalService` constructs `TerminalManager` internally, pulling in node-pty) — injecting one and pinning them with tests is recorded as follow-up work.

## Verification

- `bun run --cwd app typecheck` — clean.
- `bun test` from `app/` — **308 pass / 0 fail**.
- `bun run --cwd app build` — clean.
- `bunx @biomejs/biome check` on the changed files — clean.

---
_Generated with [Claude Code](https://claude.com/claude-code)_