### PR TITLE
Options and crypto trading support with a unified order gate

### DIFF
--- a/app/src/main/host/index.ts
+++ b/app/src/main/host/index.ts
@@ -103,6 +103,8 @@ async function main() {
   approvals.setOrderResolver(
     (orderId) => broker.getAgenticOrdersCached()?.value.find((o) => o.id === orderId) ?? null,
   );
+  // Same reverse link for option orders: turn the legs' contract ids into contracts.
+  approvals.setContractResolver((ids) => broker.resolveOptionContracts(ids));
 
   // Stable endpoint: home-derived faucet port + persisted token, shared by the
   // faucet/gate, the terminal WS, and the tRPC server.

--- a/app/src/main/services/agents/registry.test.ts
+++ b/app/src/main/services/agents/registry.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { GATED_TOOL_MATCHER, GATED_TOOLS } from "@shared/robinhood-tools";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import type { Db } from "../../db/client";
 import { SCHEMA_DDL } from "../../db/ddl";
@@ -167,15 +168,21 @@ describe("AgentRegistry — codex scaffold divergence", () => {
     const toml = readFileSync(join(codexHome, "config.toml"), "utf8");
     expect(toml).toContain('approval_policy = "on-request"');
     expect(toml).toContain("[mcp_servers.robinhood]");
-    // The fail-closed anchor: order tools ALWAYS prompt ("approve" would mean
-    // pre-approved!), everything else pre-allowed like claude's allowlist.
+    // The fail-closed anchor: every money-mover in the shared table ALWAYS prompts
+    // ("approve" would mean pre-approved!), everything else pre-allowed like
+    // claude's allowlist. Spot-check one tool per asset class + the exercise pair
+    // against literal names so a gutted table can't silently pass its own test.
+    for (const t of GATED_TOOLS) {
+      expect(toml).toContain(`[mcp_servers.robinhood.tools.${t}]\napproval_mode = "prompt"`);
+    }
     for (const t of [
       "place_equity_order",
       "place_option_order",
-      "cancel_equity_order",
-      "cancel_option_order",
+      "place_crypto_order",
+      "exercise_option",
+      "cancel_option_exercise",
     ]) {
-      expect(toml).toContain(`[mcp_servers.robinhood.tools.${t}]\napproval_mode = "prompt"`);
+      expect(GATED_TOOLS).toContain(t);
     }
     expect(toml).toContain('default_tools_approval_mode = "approve"');
     // Project trust suppresses the TUI's first-run trust prompt — keyed by the
@@ -189,7 +196,10 @@ describe("AgentRegistry — codex scaffold divergence", () => {
     // Gate hooks: claude-compatible hooks.json + executable scripts, abs paths.
     const hooks = JSON.parse(readFileSync(join(codexHome, "hooks.json"), "utf8"));
     const pre = hooks.hooks.PreToolUse[0];
-    expect(pre.matcher).toBe("mcp__robinhood__(place|cancel)_(equity|option)_order");
+    expect(pre.matcher).toBe(GATED_TOOL_MATCHER);
+    // The regex form must actually match the prefixed tool names Claude Code sees.
+    expect(new RegExp(`^${pre.matcher}$`).test("mcp__robinhood__place_crypto_order")).toBe(true);
+    expect(new RegExp(`^${pre.matcher}$`).test("mcp__robinhood__get_equity_quotes")).toBe(false);
     // The command is a shell string carrying the non-secret identifiers (codex
     // cleans the hook env; the scripts recover port/token from the manifest).
     expect(pre.hooks[0].command).toContain(join(codexHome, "hooks", "approval-gate.sh"));
@@ -233,7 +243,12 @@ describe("AgentRegistry — codex scaffold divergence", () => {
     // settings.json is present locally; clean CI builds lack it and shipped ungated.)
     const settings = JSON.parse(readFileSync(join(dir, ".claude", "settings.json"), "utf8"));
     const pre = settings.hooks.PreToolUse[0];
-    expect(pre.matcher).toBe("mcp__robinhood__(place|cancel)_(equity|option)_order");
+    expect(pre.matcher).toBe(GATED_TOOL_MATCHER);
+    expect(settings.hooks.PostToolUse[0].matcher).toBe(GATED_TOOL_MATCHER);
+    // Reads and cosmetic writes ride the allowlist; money-movers must NOT.
+    expect(settings.permissions.allow).toContain("mcp__robinhood__get_*");
+    expect(settings.permissions.allow).toContain("mcp__robinhood__add_to_watchlist");
+    expect(settings.permissions.allow).not.toContain("mcp__robinhood__place_crypto_order");
     expect(pre.hooks[0].command).toContain(".claude/hooks/approval-gate.sh");
     expect(existsSync(join(dir, ".claude", "hooks", "approval-gate.sh"))).toBe(true);
   });

--- a/app/src/main/services/analytics/analytics.test.ts
+++ b/app/src/main/services/analytics/analytics.test.ts
@@ -270,11 +270,15 @@ describe("analytics allowlist + normalizers", () => {
     expect(sideOf(null)).toBe("other");
     expect(assetTypeOf("mcp__robinhood__place_option_order")).toBe("option");
     expect(assetTypeOf("mcp__robinhood__place_equity_order")).toBe("equity");
+    expect(assetTypeOf("mcp__robinhood__place_crypto_order")).toBe("crypto");
+    expect(assetTypeOf("mcp__robinhood__exercise_option")).toBe("option");
+    expect(assetTypeOf("mcp__robinhood__cancel_option_exercise")).toBe("option");
     expect(assetTypeOf("something_else")).toBe("other");
     expect(orderTypeOf("LIMIT")).toBe("limit");
     expect(orderTypeOf("stop")).toBe("other");
     expect(orderKindOf("cancel")).toBe("cancel");
     expect(orderKindOf("place")).toBe("place");
+    expect(orderKindOf("exercise")).toBe("exercise");
     expect(templateOf("momentum")).toBe("momentum");
     expect(templateOf("custom-thing")).toBe("other");
   });

--- a/app/src/main/services/approvals/index.ts
+++ b/app/src/main/services/approvals/index.ts
@@ -8,6 +8,7 @@ import type {
   PreToolUseDecision,
 } from "@shared/approval";
 import type { OrderStatus } from "@shared/broker";
+import { legsLabel, type OptionContract } from "@shared/options";
 import { DEFAULT_SETTINGS } from "@shared/settings";
 import { and, asc, desc, eq, isNull, like } from "drizzle-orm";
 import { nanoid } from "nanoid";
@@ -18,10 +19,17 @@ import { analytics } from "../analytics";
 import type { AuditLog } from "../audit";
 import { bus } from "../event-bus";
 import type { StatusArbiter } from "../status/arbiter";
-import { enrichCancelParsed, parseOrderInput, parseOrderResult } from "./parse";
+import { enrichCancelParsed, enrichOptionParsed, parseOrderInput, parseOrderResult } from "./parse";
 
 // Shared with SettingsService, which writes the same `approval_timeout_sec` key.
 const DEFAULT_TIMEOUT_SEC = DEFAULT_SETTINGS.approvalTimeoutSec;
+/**
+ * Upper bound on resolving an option order's contract ids before the card is
+ * raised. The lookup is cache-first and normally instant; a cold miss is one MCP
+ * round-trip. Past this the card goes up unresolved (`BUY 1 option …`) rather than
+ * holding the agent's tool call — the gate must never hang on a display nicety.
+ */
+const CONTRACT_RESOLVE_MS = 4_000;
 
 interface Waiter {
   resolve: (decision: PreToolUseDecision) => void;
@@ -46,6 +54,12 @@ export class ApprovalService {
    * card with the target order's details (§6.9).
    */
   private resolveOrder: ((orderId: string) => OrderStatus | null) | null = null;
+  /**
+   * Resolve option contract ids to their identity, so an option order's card can
+   * name the contract instead of a UUID. Injected like `resolveOrder` (same
+   * dependency cycle); bounded by `CONTRACT_RESOLVE_MS`.
+   */
+  private resolveContracts: ((ids: string[]) => Promise<Map<string, OptionContract>>) | null = null;
 
   constructor(
     private db: Db,
@@ -57,6 +71,11 @@ export class ApprovalService {
   /** Wire the ledger lookup used to enrich cancel cards. Called once at boot. */
   setOrderResolver(fn: (orderId: string) => OrderStatus | null): void {
     this.resolveOrder = fn;
+  }
+
+  /** Wire the option-contract lookup used to enrich option order cards. Called once at boot. */
+  setContractResolver(fn: (ids: string[]) => Promise<Map<string, OptionContract>>): void {
+    this.resolveContracts = fn;
   }
 
   /** Seconds the user is given before an order auto-denies. */
@@ -132,8 +151,20 @@ export class ApprovalService {
           orderType: o.type,
           limitPrice: o.limitPrice,
           dollarAmount: o.dollarAmount,
+          assetType: o.assetType ?? "equity",
+          instrument: o.assetType === "option" ? legsLabel(o.legs ?? []) : null,
+          multiplier: o.multiplier ?? null,
         },
       );
+    }
+    // An option order — or an exercise — names its contracts only by UUID.
+    // Resolve them (bounded) so the card and audit trail read `TLT $86C
+    // 11/20/26`, not `option`. Applies to any option-parsed card carrying legs
+    // (an ordinary order-cancel has none; it enriched from the ledger above).
+    if (parsed.assetType === "option" && parsed.legs?.length && this.resolveContracts) {
+      const ids = parsed.legs.map((l) => l.optionId).filter(Boolean);
+      const contracts = await withTimeout(this.resolveContracts(ids), CONTRACT_RESOLVE_MS);
+      if (contracts) parsed = enrichOptionParsed(parsed, contracts);
     }
     const id = nanoid();
     const now = Date.now();
@@ -196,8 +227,13 @@ export class ApprovalService {
         this.wake(id);
       }, timeoutSec * 1000);
       this.waiters.set(id, { resolve, timer });
-      // If the agent's session dies mid-poll, the order is moot — abandon it.
-      opts?.signal?.addEventListener("abort", () => this.abandon(id), { once: true });
+      // If the agent's session dies mid-poll, the order is moot — abandon it. The
+      // signal may ALREADY be aborted (a listener added after abort never fires):
+      // the contract resolution above can await up to CONTRACT_RESOLVE_MS, and the
+      // hook can disconnect inside that window — without this check the card would
+      // sit pending for the full approval timeout.
+      if (opts?.signal?.aborted) this.abandon(id);
+      else opts?.signal?.addEventListener("abort", () => this.abandon(id), { once: true });
     });
   }
 
@@ -464,4 +500,21 @@ function safeJson<T>(text: string | null): T | null {
   } catch {
     return null;
   }
+}
+
+/** Resolve to `null` if `p` neither settles nor errors within `ms`. Never throws. */
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      () => {
+        clearTimeout(timer);
+        resolve(null);
+      },
+    );
+  });
 }

--- a/app/src/main/services/approvals/parse.test.ts
+++ b/app/src/main/services/approvals/parse.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, test } from "bun:test";
-import { enrichCancelParsed, parseOrderInput, parseOrderResult } from "./parse";
+import type { OptionContract } from "@shared/options";
+import { enrichCancelParsed, enrichOptionParsed, parseOrderInput, parseOrderResult } from "./parse";
+
+// The exact tool_input a live agent submitted (2026-08-27) — no symbol anywhere.
+const TLT_ID = "e9c444cc-5ccc-4dfe-8fd9-64daf22d6338";
+const liveOptionInput = {
+  account_number: "547526228",
+  legs: [{ option_id: TLT_ID, side: "buy", position_effect: "open" }],
+  quantity: "1",
+  type: "limit",
+  price: "0.79",
+  time_in_force: "gfd",
+  ref_id: "e5a1c8d2-9f4b-4a37-b6e0-8d2c7f1a5b93",
+};
+const tltCall: OptionContract = {
+  optionId: TLT_ID,
+  chainSymbol: "TLT",
+  expirationDate: "2026-11-20",
+  strikePrice: 86,
+  optionType: "call",
+  multiplier: 100,
+};
+const contracts = new Map([[TLT_ID, tltCall]]);
 
 describe("parseOrderInput", () => {
   test("limit buy computes est cost and a clean summary", () => {
@@ -68,8 +90,250 @@ describe("parseOrderInput", () => {
   });
 });
 
+describe("parseOrderInput — options", () => {
+  test("a live single-leg limit buy: contracts × multiplier, unresolved contract reads 'option'", () => {
+    const p = parseOrderInput("mcp__robinhood__place_option_order", liveOptionInput);
+    expect(p.kind).toBe("place");
+    expect(p.assetType).toBe("option");
+    expect(p.side).toBe("buy"); // from the leg, not a top-level field
+    expect(p.quantity).toBe(1);
+    expect(p.orderType).toBe("limit");
+    expect(p.limitPrice).toBe(0.79);
+    expect(p.estCost).toBe(79); // $0.79 × 100 × 1 — what the account is actually debited
+    expect(p.multiplier).toBe(100);
+    expect(p.symbol).toBeNull();
+    expect(p.legs?.[0]).toMatchObject({ optionId: TLT_ID, side: "buy", positionEffect: "open" });
+    expect(p.summary).toBe("BUY 1 option to open @ $0.79 limit — est. $79.00");
+  });
+
+  test("enrichOptionParsed names the contract and the underlying", () => {
+    const p = enrichOptionParsed(
+      parseOrderInput("mcp__robinhood__place_option_order", liveOptionInput),
+      contracts,
+    );
+    expect(p.symbol).toBe("TLT");
+    expect(p.instrument).toBe("TLT $86C 11/20/26");
+    expect(p.legs?.[0].contract).toEqual(tltCall);
+    expect(p.estCost).toBe(79);
+    expect(p.summary).toBe("BUY 1 TLT $86C 11/20/26 to open @ $0.79 limit — est. $79.00");
+  });
+
+  test("an unknown id stays unresolved; enrichment never throws or touches equities", () => {
+    const raw = parseOrderInput("mcp__robinhood__place_option_order", liveOptionInput);
+    expect(enrichOptionParsed(raw, new Map()).summary).toBe(raw.summary);
+    const eq = parseOrderInput("place_equity_order", { symbol: "AAPL", side: "buy", quantity: 1 });
+    expect(enrichOptionParsed(eq, contracts)).toBe(eq);
+  });
+
+  test("market sell-to-close has no estimate; stop orders show the stop", () => {
+    const base = {
+      legs: [{ option_id: TLT_ID, side: "sell", position_effect: "close" }],
+      quantity: 1,
+    };
+    const mkt = enrichOptionParsed(
+      parseOrderInput("place_option_order", { ...base, type: "market" }),
+      contracts,
+    );
+    expect(mkt.side).toBe("sell");
+    expect(mkt.estCost).toBeNull();
+    expect(mkt.summary).toBe("SELL 1 TLT $86C 11/20/26 to close @ market");
+
+    const stop = enrichOptionParsed(
+      parseOrderInput("place_option_order", { ...base, type: "stop_market", stop_price: "0.5" }),
+      contracts,
+    );
+    expect(stop.stopPrice).toBe(0.5);
+    expect(stop.summary).toBe("SELL 1 TLT $86C 11/20/26 to close @ market (stop $0.50)");
+
+    const stopLimit = enrichOptionParsed(
+      parseOrderInput("place_option_order", {
+        ...base,
+        type: "stop_limit",
+        stop_price: "0.5",
+        price: "0.45",
+      }),
+      contracts,
+    );
+    expect(stopLimit.estCost).toBe(45);
+    expect(stopLimit.summary).toBe(
+      "SELL 1 TLT $86C 11/20/26 to close @ $0.45 stop-limit (stop $0.50) — est. $45.00",
+    );
+  });
+
+  test("a bare price implies limit, as RH defaults it", () => {
+    const p = parseOrderInput("place_option_order", { ...liveOptionInput, type: undefined });
+    expect(p.orderType).toBe("limit");
+    expect(p.estCost).toBe(79);
+  });
+
+  test("a spread takes its verb from the net direction and prices the whole strategy", () => {
+    const OTHER = "11111111-2222-3333-4444-555555555555";
+    const p = enrichOptionParsed(
+      parseOrderInput("place_option_order", {
+        legs: [
+          { option_id: TLT_ID, side: "buy", position_effect: "open" },
+          { option_id: OTHER, side: "sell", position_effect: "open" },
+        ],
+        quantity: "2",
+        type: "limit",
+        price: "1.20",
+        direction: "debit",
+      }),
+      new Map([
+        [TLT_ID, tltCall],
+        [OTHER, { ...tltCall, optionId: OTHER, strikePrice: 90 }],
+      ]),
+    );
+    expect(p.side).toBe("debit");
+    expect(p.direction).toBe("debit");
+    expect(p.legs).toHaveLength(2);
+    expect(p.instrument).toBe("TLT 2-leg spread");
+    expect(p.estCost).toBe(240); // $1.20 net × 100 × 2
+    expect(p.summary).toBe("DEBIT 2 TLT 2-leg spread @ $1.20 net limit — est. $240.00");
+  });
+
+  test("an empty option input degrades gracefully", () => {
+    const p = parseOrderInput("place_option_order", {});
+    expect(p.assetType).toBe("option");
+    expect(p.summary).toBe("ORDER option @ market");
+  });
+
+  test("exercise_option: contract-resolved card with the cash needed to exercise a call", () => {
+    const raw = parseOrderInput("mcp__robinhood__exercise_option", {
+      account_number: "547526228",
+      option_id: TLT_ID,
+      quantity: 2,
+      reason: "buying_stocks",
+    });
+    expect(raw.kind).toBe("exercise");
+    expect(raw.assetType).toBe("option");
+    expect(raw.summary).toBe("EXERCISE 2 option");
+    const p = enrichOptionParsed(raw, contracts);
+    expect(p.symbol).toBe("TLT");
+    expect(p.estCost).toBe(17200); // $86 strike × 100 × 2 — the cash the exercise commits
+    expect(p.summary).toBe("EXERCISE 2 TLT $86C 11/20/26 — est. $17,200.00 to buy shares");
+  });
+
+  test("a put exercise with allow_shorts keeps the risk note through enrichment", () => {
+    const put = new Map([[TLT_ID, { ...tltCall, optionType: "put" as const }]]);
+    const p = enrichOptionParsed(
+      parseOrderInput("exercise_option", { option_id: TLT_ID, quantity: 1, allow_shorts: true }),
+      put,
+    );
+    expect(p.estCost).toBeNull(); // a put delivers shares; no cash debit to estimate
+    expect(p.summary).toBe("EXERCISE 1 TLT $86P 11/20/26 — may short shares to deliver");
+  });
+
+  test("cancel_option_exercise targets the contract, not an order id", () => {
+    const p = enrichOptionParsed(
+      parseOrderInput("mcp__robinhood__cancel_option_exercise", {
+        account_number: "547526228",
+        option_id: TLT_ID,
+      }),
+      contracts,
+    );
+    expect(p.kind).toBe("cancel");
+    expect(p.cancelsOrderId).toBeNull();
+    expect(p.summary).toBe("Cancel exercise of TLT $86C 11/20/26");
+  });
+
+  test("cancel_option_order is a cancel tagged as an option", () => {
+    const p = parseOrderInput("mcp__robinhood__cancel_option_order", {
+      account_number: "1",
+      order_id: "abc-123",
+    });
+    expect(p.kind).toBe("cancel");
+    expect(p.assetType).toBe("option");
+    expect(p.cancelsOrderId).toBe("abc-123");
+  });
+});
+
+describe("parseOrderInput — crypto", () => {
+  test("dollar-notional market buy (the common shape)", () => {
+    const p = parseOrderInput("mcp__robinhood__place_crypto_order", {
+      rhs_account_number: "547526228",
+      symbol: "BTC",
+      side: "buy",
+      type: "market",
+      dollar_amount: "100.00",
+    });
+    expect(p.kind).toBe("place");
+    expect(p.assetType).toBe("crypto");
+    expect(p.symbol).toBe("BTC");
+    expect(p.estCost).toBe(100);
+    expect(p.summary).toBe("BUY $100.00 of BTC @ market");
+  });
+
+  test("a pair symbol reads as the bare asset; limit sell in coins", () => {
+    const p = parseOrderInput("place_crypto_order", {
+      symbol: "ETH-USD",
+      side: "sell",
+      type: "limit",
+      quantity: "0.5",
+      limit_price: "2600",
+    });
+    expect(p.symbol).toBe("ETH");
+    expect(p.estCost).toBe(1300);
+    expect(p.summary).toBe("SELL 0.5 ETH @ $2,600.00 limit — est. $1,300.00");
+  });
+
+  test("stop_loss is a stop-triggered market order; stop_limit carries both prices", () => {
+    const stop = parseOrderInput("place_crypto_order", {
+      symbol: "BTC",
+      side: "sell",
+      type: "stop_loss",
+      quantity: "0.001",
+      stop_price: "70000",
+    });
+    expect(stop.stopPrice).toBe(70000);
+    expect(stop.summary).toBe("SELL 0.001 BTC @ market (stop $70,000.00)");
+
+    const stopLimit = parseOrderInput("place_crypto_order", {
+      symbol: "BTC",
+      side: "sell",
+      type: "stop_limit",
+      quantity: "0.001",
+      stop_price: "70000",
+      limit_price: "69500",
+    });
+    expect(stopLimit.summary).toBe(
+      "SELL 0.001 BTC @ $69,500.00 stop-limit (stop $70,000.00) — est. $69.50",
+    );
+  });
+
+  test("cancel_crypto_order is a cancel tagged as crypto", () => {
+    const p = parseOrderInput("mcp__robinhood__cancel_crypto_order", {
+      rhs_account_number: "547526228",
+      order_id: "abc-123",
+    });
+    expect(p.kind).toBe("cancel");
+    expect(p.assetType).toBe("crypto");
+    expect(p.cancelsOrderId).toBe("abc-123");
+  });
+});
+
 describe("enrichCancelParsed", () => {
   const bare = parseOrderInput("cancel_equity_order", { order_id: "abc-123" });
+
+  test("an option target names the contract and scales the limit by the multiplier", () => {
+    const cancel = parseOrderInput("cancel_option_order", { order_id: "abc-123" });
+    const p = enrichCancelParsed(cancel, {
+      symbol: "TLT",
+      side: "buy",
+      quantity: 1,
+      orderType: "limit",
+      limitPrice: 0.79,
+      dollarAmount: null,
+      assetType: "option",
+      instrument: "TLT $86C 11/20/26",
+      multiplier: 100,
+    });
+    expect(p.summary).toBe("Cancel BUY 1 TLT $86C 11/20/26 @ $0.79 limit");
+    expect(p.estCost).toBe(79);
+    expect(p.instrument).toBe("TLT $86C 11/20/26");
+    expect(p.assetType).toBe("option");
+    expect(p.cancelsOrderId).toBe("abc-123");
+  });
 
   test("folds a dollar-based market order into the cancel card", () => {
     const p = enrichCancelParsed(bare, {

--- a/app/src/main/services/approvals/parse.ts
+++ b/app/src/main/services/approvals/parse.ts
@@ -1,4 +1,10 @@
 import type { OrderOutcome, ParsedOrder } from "@shared/approval";
+import {
+  legsLabel,
+  type OptionContract,
+  type OptionLeg,
+  STANDARD_MULTIPLIER,
+} from "@shared/options";
 
 /**
  * Best-effort parse of a Robinhood order tool's `tool_input` into a human card.
@@ -8,7 +14,13 @@ import type { OrderOutcome, ParsedOrder } from "@shared/approval";
  */
 export function parseOrderInput(toolName: string, input: unknown): ParsedOrder {
   const o = (input ?? {}) as Record<string, unknown>;
+  // Exercise first: `cancel_option_exercise` would otherwise trip the generic
+  // cancel branch, which expects an order_id it doesn't have (it targets an
+  // option_id — exercises aren't orders and never appear in the order ledger).
+  if (/exercise/.test(toolName)) return parseExercise(toolName, o);
   const isCancel = /cancel_/.test(toolName);
+  const isOption = /_option_/.test(toolName) || Array.isArray(o.legs);
+  const isCrypto = /_crypto_/.test(toolName);
 
   if (isCancel) {
     const orderId = str(pick(o, "order_id", "id", "orderId"));
@@ -22,14 +34,23 @@ export function parseOrderInput(toolName: string, input: unknown): ParsedOrder {
       estCost: null,
       cancelsOrderId: orderId,
       summary: orderId ? `Cancel order ${orderId}` : "Cancel order",
+      ...(isOption ? { assetType: "option" as const } : {}),
+      ...(isCrypto ? { assetType: "crypto" as const } : {}),
     };
   }
 
-  const symbol = up(str(pick(o, "symbol", "ticker", "instrument")));
+  if (isOption) return parseOptionOrder(o);
+
+  // Equity and crypto orders share a flat shape (symbol/side/type/quantity or a
+  // dollar notional). Crypto extras: the symbol may be a pair ("BTC-USD" → "BTC"),
+  // quantities are coins, and `stop_loss` is what equities call `stop_market`.
+  const rawSymbol = up(str(pick(o, "symbol", "ticker", "instrument")));
+  const symbol = isCrypto && rawSymbol ? rawSymbol.replace(/-?USD$/, "") : rawSymbol;
   const side = low(str(pick(o, "side", "direction")));
   const quantity = numv(pick(o, "quantity", "qty", "shares", "amount_in_shares"));
   const orderType = low(str(pick(o, "type", "order_type", "orderType"))) ?? inferType(o);
   const limitPrice = numv(pick(o, "limit_price", "limitPrice", "price"));
+  const stopPrice = numv(pick(o, "stop_price", "stopPrice"));
   const dollars = numv(pick(o, "amount", "dollar_amount", "amount_in_dollars", "notional"));
 
   let estCost: number | null = null;
@@ -45,8 +66,248 @@ export function parseOrderInput(toolName: string, input: unknown): ParsedOrder {
     limitPrice,
     estCost,
     cancelsOrderId: null,
-    summary: placeSummary({ side, quantity, symbol, orderType, limitPrice, dollars, estCost }),
+    summary: placeSummary({
+      side,
+      quantity,
+      symbol,
+      orderType,
+      limitPrice,
+      stopPrice,
+      dollars,
+      estCost,
+    }),
+    ...(isCrypto ? { assetType: "crypto" as const, stopPrice } : {}),
   };
+}
+
+/**
+ * An option order's `tool_input` (`place_option_order`). Unlike an equity order it
+ * names no symbol: each leg carries only an `option_id` UUID, the price is per
+ * share and `quantity` counts contracts. The contract's identity (underlying,
+ * expiry, strike, call/put) is filled in afterwards by `enrichOptionParsed`, once
+ * the gate has resolved the ids — so this first pass renders `BUY 1 option to open
+ * @ $0.79 limit`, and the enriched card `BUY 1 TLT $86C 11/20/26 to open …`.
+ *
+ * Field shapes verified against the live tool schema (2026-08-27): `legs[]
+ * {option_id, side, position_effect, ratio_quantity?}`, `quantity`, `type`
+ * (limit default), `price`, `stop_price`, `direction` (multi-leg), `time_in_force`.
+ */
+function parseOptionOrder(o: Record<string, unknown>): ParsedOrder {
+  const rawLegs = Array.isArray(o.legs) ? (o.legs as unknown[]) : [];
+  const legs: OptionLeg[] = rawLegs.map((raw) => {
+    const l = (raw ?? {}) as Record<string, unknown>;
+    return {
+      optionId: str(pick(l, "option_id", "optionId", "id")) ?? "",
+      side: low(str(pick(l, "side"))),
+      positionEffect: low(str(pick(l, "position_effect", "positionEffect"))),
+      ratioQuantity: numv(pick(l, "ratio_quantity", "ratioQuantity")) ?? 1,
+      contract: null,
+    };
+  });
+  const quantity = numv(pick(o, "quantity", "qty"));
+  // RH defaults `type` to limit; a bare `price` means the same.
+  const orderType =
+    low(str(pick(o, "type", "order_type", "orderType"))) ??
+    (pick(o, "price", "limit_price") != null ? "limit" : null);
+  const limitPrice = numv(pick(o, "price", "limit_price", "limitPrice"));
+  const stopPrice = numv(pick(o, "stop_price", "stopPrice"));
+  // One leg: its side is the order's side. A spread only has a net direction
+  // (debit = you pay, credit = you receive), which stands in as the verb.
+  const direction =
+    low(str(pick(o, "direction"))) ??
+    (legs.length === 1 && legs[0].side ? (legs[0].side === "sell" ? "credit" : "debit") : null);
+  const side = legs.length === 1 ? legs[0].side : direction;
+  return buildOptionParsed({ legs, quantity, orderType, limitPrice, stopPrice, direction, side });
+}
+
+/**
+ * `exercise_option` / `cancel_option_exercise`. Not orders: the input names a
+ * position's contract by `option_id` (+ integer `quantity` for the exercise
+ * itself; the cancel targets every queued exercise on that contract). A call
+ * exercise buys `quantity × multiplier` shares at the strike, so once the
+ * contract resolves the est. cost is `strike × multiplier × quantity` (a put
+ * delivers shares instead — no cash estimate). `allow_shorts` on a put is a
+ * risk flag worth keeping on the card.
+ */
+function parseExercise(toolName: string, o: Record<string, unknown>): ParsedOrder {
+  const optionId = str(pick(o, "option_id", "optionId")) ?? "";
+  const legs: OptionLeg[] = optionId
+    ? [{ optionId, side: null, positionEffect: null, ratioQuantity: 1, contract: null }]
+    : [];
+  return buildExerciseParsed({
+    cancel: /cancel_/.test(toolName),
+    legs,
+    quantity: numv(pick(o, "quantity")),
+    allowShorts: pick(o, "allow_shorts", "allowShorts") === true,
+  });
+}
+
+/** Suffix marking `allow_shorts` on an exercise summary (also how enrichment re-detects it). */
+const ALLOW_SHORTS_NOTE = " — may short shares to deliver";
+
+function buildExerciseParsed(a: {
+  cancel: boolean;
+  legs: OptionLeg[];
+  quantity: number | null;
+  allowShorts: boolean;
+}): ParsedOrder {
+  const contract = a.legs[0]?.contract ?? null;
+  const instrument = legsLabel(a.legs);
+  const multiplier = contract?.multiplier ?? STANDARD_MULTIPLIER;
+  // Cash needed to exercise a call: buy quantity × multiplier shares at the strike.
+  const estCost =
+    !a.cancel &&
+    contract?.optionType === "call" &&
+    contract.strikePrice != null &&
+    a.quantity != null
+      ? contract.strikePrice * multiplier * a.quantity
+      : null;
+  const size = a.quantity != null ? `${trimNum(a.quantity)} ` : "";
+  const summary = a.cancel
+    ? `Cancel exercise of ${instrument}`
+    : `EXERCISE ${size}${instrument}${estCost != null ? ` — est. ${usd(estCost)} to buy shares` : ""}${
+        a.allowShorts ? ALLOW_SHORTS_NOTE : ""
+      }`;
+  return {
+    kind: a.cancel ? "cancel" : "exercise",
+    symbol: up(contract?.chainSymbol ?? null),
+    side: null,
+    quantity: a.quantity,
+    orderType: a.cancel ? "cancel" : "exercise",
+    limitPrice: null,
+    estCost,
+    cancelsOrderId: null,
+    summary,
+    assetType: "option",
+    instrument,
+    legs: a.legs,
+    multiplier,
+    direction: null,
+    stopPrice: null,
+  };
+}
+
+/**
+ * Fill in the contracts behind an option order's legs (from the broker's
+ * `option_id` → contract map) and recompute everything that depends on them: the
+ * underlying, the instrument label, the multiplier, the est. cost, the summary.
+ * Covers placed orders and exercises/exercise-cancels (an ordinary order-cancel
+ * has no legs and enriches from the ledger instead). Ids the map doesn't know
+ * keep a null contract; a non-option order is untouched.
+ */
+export function enrichOptionParsed(
+  parsed: ParsedOrder,
+  contracts: Map<string, OptionContract>,
+): ParsedOrder {
+  if (parsed.assetType !== "option" || !parsed.legs?.length) return parsed;
+  const legs = parsed.legs.map((l) => ({
+    ...l,
+    contract: contracts.get(l.optionId) ?? l.contract,
+  }));
+  if (parsed.kind === "exercise" || (parsed.kind === "cancel" && parsed.orderType === "cancel")) {
+    if (parsed.kind === "cancel" && !parsed.summary.startsWith("Cancel exercise")) return parsed;
+    return buildExerciseParsed({
+      cancel: parsed.kind === "cancel",
+      legs,
+      quantity: parsed.quantity,
+      // ParsedOrder carries no allow_shorts field; the parse-time summary does.
+      allowShorts: parsed.summary.includes(ALLOW_SHORTS_NOTE),
+    });
+  }
+  if (parsed.kind !== "place") return parsed;
+  return {
+    ...parsed,
+    ...buildOptionParsed({
+      legs,
+      quantity: parsed.quantity,
+      orderType: parsed.orderType,
+      limitPrice: parsed.limitPrice,
+      stopPrice: parsed.stopPrice ?? null,
+      direction: parsed.direction ?? null,
+      side: parsed.side,
+    }),
+  };
+}
+
+function buildOptionParsed(a: {
+  legs: OptionLeg[];
+  quantity: number | null;
+  orderType: string | null;
+  limitPrice: number | null;
+  stopPrice: number | null;
+  direction: string | null;
+  side: string | null;
+}): ParsedOrder {
+  const known = a.legs.find((l) => l.contract);
+  const multiplier = known?.contract?.multiplier ?? STANDARD_MULTIPLIER;
+  const symbol = up(known?.contract?.chainSymbol ?? null);
+  const instrument = legsLabel(a.legs);
+  // Per-share limit × multiplier × contracts: the dollars the order actually moves
+  // ($0.79 × 100 × 1 = $79). Only a priced order has an estimate.
+  const priced = a.orderType === "limit" || a.orderType === "stop_limit";
+  const estCost =
+    priced && a.limitPrice != null && a.quantity != null
+      ? a.limitPrice * multiplier * a.quantity
+      : null;
+  return {
+    kind: "place",
+    symbol,
+    side: a.side,
+    quantity: a.quantity,
+    orderType: a.orderType,
+    limitPrice: a.limitPrice,
+    estCost,
+    cancelsOrderId: null,
+    summary: optionSummary({ ...a, instrument, estCost }),
+    assetType: "option",
+    instrument,
+    legs: a.legs,
+    multiplier,
+    direction: a.direction,
+    stopPrice: a.stopPrice,
+  };
+}
+
+/**
+ * `BUY 1 TLT $86C 11/20/26 to open @ $0.79 limit — est. $79.00`;
+ * `DEBIT 2 TLT 2-leg spread @ $1.20 net limit — est. $240.00`;
+ * `SELL 1 TLT $86C 11/20/26 to close @ market (stop $0.50)`.
+ */
+function optionSummary(a: {
+  legs: OptionLeg[];
+  quantity: number | null;
+  orderType: string | null;
+  limitPrice: number | null;
+  stopPrice: number | null;
+  side: string | null;
+  instrument: string;
+  estCost: number | null;
+}): string {
+  const verb = a.side ? a.side.toUpperCase() : "ORDER";
+  const size = a.quantity != null ? `${trimNum(a.quantity)} ` : "";
+  const effect =
+    a.legs.length === 1 && a.legs[0].positionEffect ? ` to ${a.legs[0].positionEffect}` : "";
+  const net = a.legs.length > 1 ? " net" : "";
+  let price: string;
+  switch (a.orderType) {
+    case "limit":
+      price = a.limitPrice != null ? `@ ${usd(a.limitPrice)}${net} limit` : "@ limit";
+      break;
+    case "stop_limit":
+      price = `@ ${a.limitPrice != null ? usd(a.limitPrice) : "?"} stop-limit${stopClause(a.stopPrice)}`;
+      break;
+    case "stop_market":
+      price = `@ market${stopClause(a.stopPrice)}`;
+      break;
+    default:
+      price = "@ market";
+  }
+  const est = a.estCost != null ? ` — est. ${usd(a.estCost)}` : "";
+  return `${verb} ${size}${a.instrument}${effect} ${price}${est}`.replace(/\s+/g, " ").trim();
+}
+
+function stopClause(stop: number | null): string {
+  return stop != null ? ` (stop ${usd(stop)})` : "";
 }
 
 /**
@@ -54,7 +315,9 @@ export function parseOrderInput(toolName: string, input: unknown): ParsedOrder {
  * tool call only carries the target order id, so on its own it reads as a bare
  * uuid ("Cancel order <uuid>"). Resolving that id against the broker's cached
  * ledger (which includes orders placed manually in the Robinhood app, not just
- * agent-placed ones) lets us render the real order — "Cancel BUY $5 of NET".
+ * agent-placed ones) lets us render the real order — "Cancel BUY $5 of NET". For
+ * an option order `instrument` names the contract (`TLT $86C 11/20/26`) and
+ * `multiplier` scales the per-share limit into dollars.
  */
 export interface CancelTarget {
   symbol: string | null;
@@ -63,6 +326,9 @@ export interface CancelTarget {
   orderType: string | null;
   limitPrice: number | null;
   dollarAmount: number | null;
+  assetType?: "equity" | "option" | "crypto";
+  instrument?: string | null;
+  multiplier?: number | null;
 }
 
 /**
@@ -74,14 +340,17 @@ export interface CancelTarget {
  */
 export function enrichCancelParsed(parsed: ParsedOrder, target: CancelTarget | null): ParsedOrder {
   if (parsed.kind !== "cancel" || !target) return parsed;
+  const isOption = target.assetType === "option";
   const symbol = up(target.symbol);
   const side = low(target.side);
   const quantity = target.quantity && target.quantity > 0 ? target.quantity : null;
   const orderType = low(target.orderType);
   const limitPrice = target.limitPrice ?? null;
   const dollars = target.dollarAmount ?? null;
+  const multiplier = isOption ? (target.multiplier ?? STANDARD_MULTIPLIER) : 1;
   const estCost =
-    limitPrice != null && quantity != null ? limitPrice * quantity : (dollars ?? null);
+    limitPrice != null && quantity != null ? limitPrice * multiplier * quantity : (dollars ?? null);
+  const instrument = isOption ? (target.instrument ?? "option") : null;
   return {
     ...parsed,
     symbol: symbol ?? parsed.symbol,
@@ -90,19 +359,28 @@ export function enrichCancelParsed(parsed: ParsedOrder, target: CancelTarget | n
     orderType: orderType ?? parsed.orderType,
     limitPrice,
     estCost,
-    summary: cancelSummary({ side, quantity, symbol, orderType, limitPrice, dollars }),
+    summary: cancelSummary({
+      side,
+      quantity,
+      name: instrument ?? symbol,
+      orderType,
+      limitPrice,
+      dollars,
+    }),
+    ...(isOption ? { assetType: "option" as const, instrument, multiplier } : {}),
   };
 }
 
 function cancelSummary(a: {
   side: string | null;
   quantity: number | null;
-  symbol: string | null;
+  /** What's being cancelled: the symbol, or an option's contract label. */
+  name: string | null;
   orderType: string | null;
   limitPrice: number | null;
   dollars: number | null;
 }): string {
-  if (!a.symbol) return "Cancel order";
+  if (!a.name) return "Cancel order";
   const verb = a.side ? a.side.toUpperCase() : "";
   const size =
     a.quantity != null
@@ -112,7 +390,7 @@ function cancelSummary(a: {
         : "";
   const price =
     a.orderType === "limit" && a.limitPrice != null ? ` @ ${usd(a.limitPrice)} limit` : "";
-  return `Cancel ${verb} ${size}${a.symbol}${price}`.replace(/\s+/g, " ").trim();
+  return `Cancel ${verb} ${size}${a.name}${price}`.replace(/\s+/g, " ").trim();
 }
 
 function placeSummary(a: {
@@ -121,6 +399,7 @@ function placeSummary(a: {
   symbol: string | null;
   orderType: string | null;
   limitPrice: number | null;
+  stopPrice?: number | null;
   dollars: number | null;
   estCost: number | null;
 }): string {
@@ -132,8 +411,22 @@ function placeSummary(a: {
         ? `${usd(a.dollars)} of `
         : "";
   const sym = a.symbol ?? "?";
-  const price =
-    a.orderType === "limit" && a.limitPrice != null ? `@ ${usd(a.limitPrice)} limit` : "@ market";
+  let price: string;
+  switch (a.orderType) {
+    case "limit":
+      price = a.limitPrice != null ? `@ ${usd(a.limitPrice)} limit` : "@ limit";
+      break;
+    case "stop_limit":
+      price = `@ ${a.limitPrice != null ? usd(a.limitPrice) : "?"} stop-limit${stopClause(a.stopPrice ?? null)}`;
+      break;
+    // Crypto names the stop-triggered market order `stop_loss`; equities `stop_market`.
+    case "stop_loss":
+    case "stop_market":
+      price = `@ market${stopClause(a.stopPrice ?? null)}`;
+      break;
+    default:
+      price = "@ market";
+  }
   const est = a.estCost != null && a.quantity != null ? ` — est. ${usd(a.estCost)}` : "";
   return `${verb} ${size}${sym} ${price}${est}`.replace(/\s+/g, " ").trim();
 }

--- a/app/src/main/services/broker/adapter.ts
+++ b/app/src/main/services/broker/adapter.ts
@@ -1,4 +1,15 @@
-import type { Account, OrderStatus, Portfolio, Position, Quote } from "@shared/broker";
+import type {
+  Account,
+  CryptoPosition,
+  CryptoQuote,
+  OptionContract,
+  OptionPosition,
+  OptionQuote,
+  OrderStatus,
+  Portfolio,
+  Position,
+  Quote,
+} from "@shared/broker";
 
 /** MCP server entry the app writes into agents' .mcp.json. */
 export interface McpServerConfig {
@@ -59,8 +70,31 @@ export interface BrokerAdapter {
   /** Single-order lookup by id (resolves orders aged out of the ledger window). */
   getOrder(accountNumber: string, orderId: string): Promise<OrderStatus | null>;
   getQuotes(symbols: string[]): Promise<Quote[]>;
-  /** Tool names that place/cancel orders — feeds the approval-gate hook matcher. */
-  orderToolNames(): string[];
+
+  // ---- options (optional: a broker without an options API simply has none) ----
+
+  /** The option order ledger, same contract as `getAgenticOrders`. */
+  getOptionOrders?(
+    accountNumber: string,
+    opts?: { createdAtGte?: string; cursor?: string },
+  ): Promise<{ orders: OrderStatus[]; cursor: string | null }>;
+  getOptionOrder?(accountNumber: string, orderId: string): Promise<OrderStatus | null>;
+  /** Open (non-zero) option positions. */
+  getOptionPositions?(accountNumber: string): Promise<OptionPosition[]>;
+  /** Resolve contract ids to their identity (underlying / expiry / strike / type). */
+  getOptionContracts?(optionIds: string[]): Promise<OptionContract[]>;
+  getOptionQuotes?(optionIds: string[]): Promise<OptionQuote[]>;
+
+  // ---- crypto (optional, same convention; keyed by the numeric rhs account) ----
+
+  getCryptoOrders?(
+    rhsAccountNumber: string,
+    opts?: { createdAtGte?: string; cursor?: string },
+  ): Promise<{ orders: OrderStatus[]; cursor: string | null }>;
+  getCryptoOrder?(rhsAccountNumber: string, orderId: string): Promise<OrderStatus | null>;
+  getCryptoPositions?(rhsAccountNumber: string): Promise<CryptoPosition[]>;
+  /** Quotes by pair symbol ("BTC-USD"); results come back unhyphenated ("BTCUSD"). */
+  getCryptoQuotes?(pairSymbols: string[]): Promise<CryptoQuote[]>;
   /** What to write into an agent's .mcp.json. */
   mcpServerConfig(): { name: string; config: McpServerConfig };
 }

--- a/app/src/main/services/broker/crypto-positions.test.ts
+++ b/app/src/main/services/broker/crypto-positions.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import type { CryptoPosition, CryptoQuote, Portfolio } from "@shared/broker";
+import { enrichCryptoPosition, withDayChange } from "./index";
+
+const portfolio = (equity: number): Portfolio => ({
+  accountNumber: "X",
+  equity,
+  marketValue: null,
+  buyingPower: null,
+  cash: null,
+  dayChange: null,
+  dayChangePct: null,
+});
+
+const raw = (over: Partial<CryptoPosition> = {}): CryptoPosition => ({
+  assetCode: "BTC",
+  quantity: 0.002,
+  transferableQuantity: 0.002,
+  avgCost: 80000,
+  directQuantity: 0.002,
+  intradayQuantity: 0,
+  lastPrice: null,
+  previousClose: null,
+  marketValue: null,
+  unrealizedPnl: null,
+  ...over,
+});
+
+const quote = (mark: number, previousClose: number): CryptoQuote => ({
+  symbol: "BTCUSD",
+  mark,
+  bidPrice: null,
+  askPrice: null,
+  previousClose,
+});
+
+describe("enrichCryptoPosition", () => {
+  test("folds mark into price, value, and P&L against the direct basis", () => {
+    const p = enrichCryptoPosition(raw(), quote(78691.76, 77747.08));
+    expect(p.lastPrice).toBeCloseTo(78691.76);
+    expect(p.previousClose).toBeCloseTo(77747.08);
+    expect(p.marketValue).toBeCloseTo(157.38, 1);
+    expect(p.unrealizedPnl).toBeCloseTo(-2.62, 1); // bought at 80k, now 78.7k, ×0.002
+  });
+
+  test("mixed-basis holding: P&L covers only the directly purchased lots", () => {
+    // 0.003 BTC held, but only 0.002 was bought directly — the transferred 0.001
+    // has no basis, so its P&L is unknown, never extrapolated from the others'.
+    const p = enrichCryptoPosition(
+      raw({ quantity: 0.003, directQuantity: 0.002 }),
+      quote(78691.76, 77747.08),
+    );
+    expect(p.marketValue).toBeCloseTo(78691.76 * 0.003); // value covers everything
+    expect(p.unrealizedPnl).toBeCloseTo((78691.76 - 80000) * 0.002); // P&L only known lots
+  });
+
+  test("no basis → value but no P&L; no quote → untouched", () => {
+    const noBasis = enrichCryptoPosition(
+      raw({ avgCost: null, directQuantity: null }),
+      quote(78691.76, 77747.08),
+    );
+    expect(noBasis.marketValue).not.toBeNull();
+    expect(noBasis.unrealizedPnl).toBeNull();
+    expect(enrichCryptoPosition(raw(), undefined).lastPrice).toBeNull();
+  });
+});
+
+describe("withDayChange — crypto", () => {
+  test("coins held overnight move from the midnight-ET boundary close", () => {
+    const p = withDayChange(
+      portfolio(1000),
+      [],
+      new Map(),
+      [],
+      [enrichCryptoPosition(raw(), quote(78691.76, 77747.08))],
+    );
+    expect(p.dayChange).toBeCloseTo((78691.76 - 77747.08) * 0.002);
+  });
+
+  test("coins bought today move from their basis; no quote → skipped", () => {
+    const today = withDayChange(
+      portfolio(1000),
+      [],
+      new Map(),
+      [],
+      [enrichCryptoPosition(raw({ intradayQuantity: 0.002 }), quote(78691.76, 77747.08))],
+    );
+    expect(today.dayChange).toBeCloseTo((78691.76 - 80000) * 0.002);
+
+    const noQuote = withDayChange(portfolio(1000), [], new Map(), [], [raw()]);
+    expect(noQuote.dayChange).toBeNull();
+  });
+});

--- a/app/src/main/services/broker/index.ts
+++ b/app/src/main/services/broker/index.ts
@@ -2,11 +2,17 @@ import { errorNameOf } from "@shared/analytics";
 import type {
   Account,
   BrokerConnectionStatus,
+  CryptoPosition,
+  CryptoQuote,
+  OptionContract,
+  OptionPosition,
+  OptionQuote,
   OrderStatus,
   Portfolio,
   Position,
   Quote,
 } from "@shared/broker";
+import { STANDARD_MULTIPLIER } from "@shared/options";
 import { eq } from "drizzle-orm";
 import type { Db } from "../../db/client";
 import { brokerCache } from "../../db/schema";
@@ -100,8 +106,15 @@ export class BrokerService {
   private focused = false;
   /** Guards against overlapping polls when a poll outlasts the poll interval. */
   private polling = false;
-  /** Canonical order ledger, merged across full sweeps + recent polls, keyed by id. */
+  /** Canonical order ledger (equity + option), merged across full sweeps + recent polls, keyed by id. */
   private ledger = new Map<string, OrderStatus>();
+  /**
+   * Every option contract we've learned the identity of, by `option_id`. Seeded
+   * from the ledger's legs (each carries expiry/strike/type) and from
+   * `get_option_instruments` lookups; persisted under cache key `option_contracts`
+   * so a restart doesn't re-resolve. Contracts are immutable, so this never expires.
+   */
+  private contracts = new Map<string, OptionContract>();
   /** When the last full-history sweep ran; 0 forces a sweep on the next poll. */
   private lastFullSweepAt = 0;
   /**
@@ -128,6 +141,9 @@ export class BrokerService {
     bus.onEvent("settings:changed", () => {
       if (this.timer) this.startPolling();
     });
+    for (const c of this.readCache<OptionContract[]>("option_contracts")?.value ?? []) {
+      if (c?.optionId) this.contracts.set(c.optionId, c);
+    }
   }
 
   getStatus(): BrokerConnectionStatus {
@@ -136,10 +152,6 @@ export class BrokerService {
 
   getAccount(): Account | null {
     return this.account;
-  }
-
-  orderToolNames(): string[] {
-    return this.adapter.orderToolNames();
   }
 
   mcpServerConfig() {
@@ -306,8 +318,43 @@ export class BrokerService {
       this.writeCache("positions", enriched);
       updated.push("positions");
 
+      // Options and crypto positions are ISOLATED failure domains: their APIs are
+      // newer (crypto row shapes not yet live-verified), and a persistent failure
+      // there must not stall the equity/portfolio refresh above or the order-ledger
+      // sync below. On failure: keep the last cached value, log once per distinct
+      // failure, and carry on. (The ledger stays all-or-nothing by design — the
+      // "no match = definitive non-execution" verdict needs a COMPLETE ledger, so
+      // a failed sweep keeping the previous complete one is safer than a partial.)
+      // Options: positions name only the contract id + underlying; the contract's
+      // strike/type comes from the resolved-contract map and the price from a quote.
+      let optionPositions: OptionPosition[] = [];
+      try {
+        optionPositions = await this.pollOptionPositions(acct);
+        this.writeCache("option_positions", optionPositions);
+        updated.push("option_positions");
+        this.assetPollWarnings.delete("option positions");
+      } catch (err) {
+        this.warnAssetPoll("option positions", describeError(err));
+        optionPositions = this.readCache<OptionPosition[]>("option_positions")?.value ?? [];
+      }
+
+      // Crypto: positions carry no price either; fold in the pair quotes' mark.
+      let cryptoPositions: CryptoPosition[] = [];
+      try {
+        cryptoPositions = await this.pollCryptoPositions();
+        this.writeCache("crypto_positions", cryptoPositions);
+        updated.push("crypto_positions");
+        this.assetPollWarnings.delete("crypto positions");
+      } catch (err) {
+        this.warnAssetPoll("crypto positions", describeError(err));
+        cryptoPositions = this.readCache<CryptoPosition[]>("crypto_positions")?.value ?? [];
+      }
+
       // Today's account move: derived here because get_portfolio doesn't carry it.
-      this.writeCache("portfolio", withDayChange(portfolio, positions, quoteBySymbol));
+      this.writeCache(
+        "portfolio",
+        withDayChange(portfolio, positions, quoteBySymbol, optionPositions, cryptoPositions),
+      );
       updated.push("portfolio");
 
       await this.syncLedger(acct);
@@ -330,6 +377,16 @@ export class BrokerService {
     } finally {
       this.polling = false;
     }
+  }
+
+  /** Last logged failure per isolated asset domain, so a persistent option/crypto
+   *  fault writes ONE host.log line per distinct message, not one per 5s poll. */
+  private assetPollWarnings = new Map<string, string>();
+
+  private warnAssetPoll(domain: string, description: string): void {
+    if (this.assetPollWarnings.get(domain) === description) return;
+    this.assetPollWarnings.set(domain, description);
+    hostLog.warn(`${domain} poll failed: ${description}`);
   }
 
   // ---- poll-failure logging (deduped) ----
@@ -405,11 +462,134 @@ export class BrokerService {
   getAgenticOrdersCached(): { value: OrderStatus[]; fetchedAt: number } | null {
     return this.readCache<OrderStatus[]>("agentic_orders");
   }
+  getCachedOptionPositions(): { value: OptionPosition[]; fetchedAt: number } | null {
+    return this.readCache<OptionPosition[]>("option_positions");
+  }
+  getCachedCryptoPositions(): { value: CryptoPosition[]; fetchedAt: number } | null {
+    return this.readCache<CryptoPosition[]>("crypto_positions");
+  }
+
+  /** The numeric brokerage id crypto tools key on (falls back to the account number). */
+  private rhsAccount(): string | null {
+    return this.account ? (this.account.rhsAccountNumber ?? this.account.accountNumber) : null;
+  }
 
   /** Single-order lookup by id (resolves orders aged out of the poll window). */
   async getOrder(orderId: string): Promise<OrderStatus | null> {
     if (!this.account) return null;
-    return this.adapter.getOrder(this.account.accountNumber, orderId);
+    const acct = this.account.accountNumber;
+    const rhs = this.rhsAccount();
+    return (
+      (await this.adapter.getOrder(acct, orderId)) ??
+      (await this.adapter.getOptionOrder?.(acct, orderId)) ??
+      (rhs ? await this.adapter.getCryptoOrder?.(rhs, orderId) : null) ??
+      null
+    );
+  }
+
+  // ---- option contracts ----
+
+  /**
+   * Resolve option contract ids to their identity, for the approval gate's card
+   * (an order's `tool_input` names a contract only by UUID). Cache-first: the map
+   * already holds every contract the ledger or positions have ever mentioned;
+   * only genuinely new contracts (a first trade in a strike) go to
+   * `get_option_instruments`, in one batched call. Unknown ids are simply absent
+   * from the result — the card degrades to "option", never fails.
+   */
+  async resolveOptionContracts(optionIds: string[]): Promise<Map<string, OptionContract>> {
+    const out = new Map<string, OptionContract>();
+    const missing: string[] = [];
+    for (const id of new Set(optionIds)) {
+      const c = this.contracts.get(id);
+      if (c) out.set(id, c);
+      else missing.push(id);
+    }
+    if (missing.length > 0 && this.status === "connected" && this.adapter.getOptionContracts) {
+      const fetched = await this.adapter.getOptionContracts(missing);
+      this.rememberContracts(fetched);
+      for (const c of fetched) out.set(c.optionId, c);
+    }
+    return out;
+  }
+
+  /** Learn contracts (from a lookup or a ledger's legs) and persist the map. */
+  private rememberContracts(contracts: Iterable<OptionContract | null | undefined>): void {
+    let changed = false;
+    for (const c of contracts) {
+      if (!c?.optionId) continue;
+      const prev = this.contracts.get(c.optionId);
+      // Keep the most complete record; a ledger leg may lack a field a lookup has.
+      const merged: OptionContract = {
+        optionId: c.optionId,
+        chainSymbol: c.chainSymbol ?? prev?.chainSymbol ?? null,
+        expirationDate: c.expirationDate ?? prev?.expirationDate ?? null,
+        strikePrice: c.strikePrice ?? prev?.strikePrice ?? null,
+        optionType: c.optionType ?? prev?.optionType ?? null,
+        multiplier: c.multiplier ?? prev?.multiplier ?? null,
+      };
+      if (JSON.stringify(merged) !== JSON.stringify(prev)) {
+        this.contracts.set(c.optionId, merged);
+        changed = true;
+      }
+    }
+    if (changed) this.writeCache("option_contracts", [...this.contracts.values()]);
+  }
+
+  /**
+   * Open option positions with their contract identity and a live quote folded in.
+   * Positions carry neither (RH: "look up strike/type via get_option_instruments";
+   * price via get_option_quotes). Empty when the adapter has no options API.
+   */
+  private async pollOptionPositions(account: string): Promise<OptionPosition[]> {
+    if (!this.adapter.getOptionPositions) return [];
+    const raw = await this.adapter.getOptionPositions(account);
+    if (raw.length === 0) return [];
+    const ids = raw.map((p) => p.optionId).filter(Boolean);
+    const contracts = await this.resolveOptionContracts(ids);
+    const quotes = new Map<string, OptionQuote>();
+    if (this.adapter.getOptionQuotes) {
+      for (const q of await this.adapter.getOptionQuotes(ids)) quotes.set(q.optionId, q);
+    }
+    const positions = raw.map((p) =>
+      enrichOptionPosition(p, contracts.get(p.optionId), quotes.get(p.optionId)),
+    );
+    return positions;
+  }
+
+  /** Faucet: cached option positions if fresh enough, else a live poll. */
+  async getOptionPositionsLive(maxAgeMs: number): Promise<OptionPosition[]> {
+    const cached = this.readCache<OptionPosition[]>("option_positions");
+    if (cached && Date.now() - cached.fetchedAt <= maxAgeMs) return cached.value;
+    if (this.status === "connected") await this.pollOnce();
+    return this.readCache<OptionPosition[]>("option_positions")?.value ?? cached?.value ?? [];
+  }
+
+  /**
+   * Open crypto holdings with each pair's quote folded in (positions ship without
+   * a price, like equities). Quotes come back with unhyphenated symbols ("BTCUSD"),
+   * so they're matched to positions by `assetCode + "USD"`. Empty when the adapter
+   * has no crypto API or the account holds no coins.
+   */
+  private async pollCryptoPositions(): Promise<CryptoPosition[]> {
+    const rhs = this.rhsAccount();
+    if (!rhs || !this.adapter.getCryptoPositions) return [];
+    const raw = await this.adapter.getCryptoPositions(rhs);
+    if (raw.length === 0) return [];
+    const quotes = new Map<string, CryptoQuote>();
+    if (this.adapter.getCryptoQuotes) {
+      const pairs = raw.map((p) => `${p.assetCode}-USD`);
+      for (const q of await this.adapter.getCryptoQuotes(pairs)) quotes.set(q.symbol, q);
+    }
+    return raw.map((p) => enrichCryptoPosition(p, quotes.get(`${p.assetCode}USD`)));
+  }
+
+  /** Faucet: cached crypto positions if fresh enough, else a live poll. */
+  async getCryptoPositionsLive(maxAgeMs: number): Promise<CryptoPosition[]> {
+    const cached = this.readCache<CryptoPosition[]>("crypto_positions");
+    if (cached && Date.now() - cached.fetchedAt <= maxAgeMs) return cached.value;
+    if (this.status === "connected") await this.pollOnce();
+    return this.readCache<CryptoPosition[]>("crypto_positions")?.value ?? cached?.value ?? [];
   }
 
   /**
@@ -460,23 +640,49 @@ export class BrokerService {
   }
 
   /**
-   * Page through the account's order history via the pagination cursor. With no
-   * `createdAtGte` this walks the *entire* history (higher page cap); with one it
-   * fetches just that recent window. RH's list for this account is small, so even
-   * a full sweep is a handful of calls; the page guard caps it defensively.
+   * Page through the account's order history via the pagination cursor — the
+   * equity ledger plus, when the adapter has them, the option and crypto ledgers
+   * (RH keeps three lists; we hold one). With no `createdAtGte` this walks the
+   * *entire* history (higher page cap); with one it fetches just that recent
+   * window. RH's lists for this account are small, so even a full sweep is a
+   * handful of calls; the page guard caps it defensively. Option orders' legs name
+   * their contracts, so the contract map learns every traded contract for free here.
    */
   private async fetchHistory(
     account: string,
     opts: { createdAtGte?: string },
   ): Promise<OrderStatus[]> {
-    const maxPages = opts.createdAtGte ? 20 : 100;
+    const all = await this.fetchPages((cursor) =>
+      this.adapter.getAgenticOrders(account, { createdAtGte: opts.createdAtGte, cursor }),
+    );
+    const getOptionOrders = this.adapter.getOptionOrders?.bind(this.adapter);
+    if (getOptionOrders) {
+      const options = await this.fetchPages((cursor) =>
+        getOptionOrders(account, { createdAtGte: opts.createdAtGte, cursor }),
+      );
+      this.rememberContracts(options.flatMap((o) => (o.legs ?? []).map((l) => l.contract)));
+      all.push(...options);
+    }
+    const rhs = this.rhsAccount();
+    const getCryptoOrders = this.adapter.getCryptoOrders?.bind(this.adapter);
+    if (rhs && getCryptoOrders) {
+      all.push(
+        ...(await this.fetchPages((cursor) =>
+          getCryptoOrders(rhs, { createdAtGte: opts.createdAtGte, cursor }),
+        )),
+      );
+    }
+    return all;
+  }
+
+  private async fetchPages(
+    fetch: (cursor?: string) => Promise<{ orders: OrderStatus[]; cursor: string | null }>,
+    maxPages = 100,
+  ): Promise<OrderStatus[]> {
     const all: OrderStatus[] = [];
     let cursor: string | undefined;
     for (let page = 0; page < maxPages; page++) {
-      const { orders, cursor: next } = await this.adapter.getAgenticOrders(account, {
-        createdAtGte: opts.createdAtGte,
-        cursor,
-      });
+      const { orders, cursor: next } = await fetch(cursor);
       all.push(...orders);
       if (!next) break;
       cursor = next;
@@ -525,16 +731,79 @@ function enrichPosition(p: Position, quote: Quote | undefined): Position {
 }
 
 /**
+ * Fold a contract's identity and live quote into an option position. Units follow
+ * RH: the quote is per share, the position's `averagePrice` is per contract with
+ * the multiplier already in — so P&L is `(mark × multiplier − averagePrice) ×
+ * contracts`, inverted for a short.
+ */
+export function enrichOptionPosition(
+  p: OptionPosition,
+  contract: OptionContract | undefined,
+  quote: OptionQuote | undefined,
+): OptionPosition {
+  const out: OptionPosition = {
+    ...p,
+    strikePrice: contract?.strikePrice ?? p.strikePrice,
+    optionType: contract?.optionType ?? p.optionType,
+    expirationDate: p.expirationDate ?? contract?.expirationDate ?? null,
+    multiplier: p.multiplier ?? contract?.multiplier ?? null,
+  };
+  const mark = quote?.mark ?? null;
+  if (mark === null) return out;
+  const mult = out.multiplier ?? STANDARD_MULTIPLIER;
+  const sign = out.type === "short" ? -1 : 1;
+  const perContract = mark * mult;
+  return {
+    ...out,
+    lastPrice: mark,
+    previousClose: quote?.previousClose ?? null,
+    marketValue: perContract * p.quantity * sign,
+    unrealizedPnl:
+      p.averagePrice !== null ? (perContract - p.averagePrice) * p.quantity * sign : null,
+  };
+}
+
+/**
+ * Fold a pair quote into a crypto holding: mark → lastPrice, market value, and
+ * P&L. The cost basis covers only **directly purchased** coins (transfers,
+ * rewards, and forks carry none), so P&L is computed over `directQuantity` — the
+ * lots whose cost is actually known — never extrapolated across the whole
+ * holding. Identical to whole-position P&L in the common all-direct case; null
+ * when no lot has a basis. All per coin; no multiplier, no shorts.
+ */
+export function enrichCryptoPosition(
+  p: CryptoPosition,
+  quote: CryptoQuote | undefined,
+): CryptoPosition {
+  const mark = quote?.mark ?? null;
+  if (mark === null) return p;
+  const basisQty = p.directQuantity ?? 0;
+  return {
+    ...p,
+    lastPrice: mark,
+    previousClose: quote?.previousClose ?? null,
+    marketValue: mark * p.quantity,
+    unrealizedPnl: p.avgCost !== null && basisQty > 0 ? (mark - p.avgCost) * basisQty : null,
+  };
+}
+
+/**
  * Derive today's account $/% move and attach it to the portfolio. Robinhood
  * doesn't return a daily figure, so we sum each position's intraday-aware change
  * (RH's own method): shares held since yesterday move from previous_close; shares
- * bought today move from their cost basis. % is against the prior account value
- * (total − today's change). Positions without a usable quote are skipped.
+ * bought today move from their cost basis. Option positions contribute the same
+ * way in contract units (× multiplier, inverted for a short); crypto in coins,
+ * against the prior **midnight-ET** boundary close (RH's "previous close" for a
+ * 24/7 market — so "Today" for crypto means "since midnight ET"). % is against
+ * the prior account value (total − today's change). Positions without a usable
+ * quote are skipped.
  */
 export function withDayChange(
   portfolio: Portfolio,
   positions: Position[],
   quotes: Map<string, Quote>,
+  optionPositions: OptionPosition[] = [],
+  cryptoPositions: CryptoPosition[] = [],
 ): Portfolio {
   let dayChange = 0;
   let counted = 0;
@@ -545,6 +814,33 @@ export function withDayChange(
     const overnight = p.quantity - intraday;
     const costToday = p.averageCost ?? q.last; // best available basis for today's shares
     dayChange += (q.last - q.previousClose) * overnight + (q.last - costToday) * intraday;
+    counted++;
+  }
+  for (const p of optionPositions) {
+    // Prices ride the enriched position itself (folded from the contract quote at
+    // enrichment) — like crypto below. Reading them here, not a parallel quote map,
+    // keeps options in "Today" even when a poll served cached positions (an
+    // options-API outage would otherwise silently drop their whole contribution).
+    if (p.lastPrice === null || p.previousClose === null) continue;
+    const mult = p.multiplier ?? STANDARD_MULTIPLIER;
+    const sign = p.type === "short" ? -1 : 1;
+    const intraday = p.intradayQuantity ?? 0;
+    const overnight = p.quantity - intraday;
+    // Today's contracts move from their own (per-contract, multiplier-included) basis.
+    const costToday = p.intradayAverageOpenPrice ?? p.averagePrice ?? p.lastPrice * mult;
+    dayChange +=
+      ((p.lastPrice - p.previousClose) * mult * overnight +
+        (p.lastPrice * mult - costToday) * intraday) *
+      sign;
+    counted++;
+  }
+  for (const p of cryptoPositions) {
+    // Prices ride the enriched position itself (folded from the pair quote).
+    if (p.lastPrice === null || p.previousClose === null) continue;
+    const intraday = p.intradayQuantity ?? 0;
+    const overnight = p.quantity - intraday;
+    const costToday = p.avgCost ?? p.lastPrice;
+    dayChange += (p.lastPrice - p.previousClose) * overnight + (p.lastPrice - costToday) * intraday;
     counted++;
   }
   if (counted === 0) return { ...portfolio, dayChange: null, dayChangePct: null };

--- a/app/src/main/services/broker/option-positions.test.ts
+++ b/app/src/main/services/broker/option-positions.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import type { OptionContract, OptionPosition, OptionQuote, Portfolio } from "@shared/broker";
+import { enrichOptionPosition, withDayChange } from "./index";
+
+const TLT_ID = "e9c444cc-5ccc-4dfe-8fd9-64daf22d6338";
+
+const portfolio = (equity: number): Portfolio => ({
+  accountNumber: "X",
+  equity,
+  marketValue: null,
+  buyingPower: null,
+  cash: null,
+  dayChange: null,
+  dayChangePct: null,
+});
+
+/** The live TLT position as the mapper leaves it: no strike/type, no price. */
+const raw = (over: Partial<OptionPosition> = {}): OptionPosition => ({
+  optionId: TLT_ID,
+  chainId: "c",
+  chainSymbol: "TLT",
+  type: "long",
+  quantity: 1,
+  intradayQuantity: 1,
+  averagePrice: 79,
+  intradayAverageOpenPrice: 79,
+  expirationDate: "2026-11-20",
+  multiplier: 100,
+  strikePrice: null,
+  optionType: null,
+  lastPrice: null,
+  previousClose: null,
+  marketValue: null,
+  unrealizedPnl: null,
+  pendingQuantity: 0,
+  ...over,
+});
+
+const contract: OptionContract = {
+  optionId: TLT_ID,
+  chainSymbol: "TLT",
+  expirationDate: "2026-11-20",
+  strikePrice: 86,
+  optionType: "call",
+  multiplier: 100,
+};
+
+const quote = (mark: number, previousClose: number): OptionQuote => ({
+  optionId: TLT_ID,
+  mark,
+  bidPrice: null,
+  askPrice: null,
+  previousClose,
+  impliedVolatility: null,
+  delta: null,
+  theta: null,
+});
+
+describe("enrichOptionPosition", () => {
+  test("folds in the contract identity and prices in contract units", () => {
+    const p = enrichOptionPosition(raw(), contract, quote(0.765, 0.85));
+    expect(p.strikePrice).toBe(86);
+    expect(p.optionType).toBe("call");
+    expect(p.lastPrice).toBe(0.765); // per share, as quoted
+    expect(p.previousClose).toBe(0.85);
+    expect(p.marketValue).toBeCloseTo(76.5); // 0.765 × 100 × 1
+    expect(p.unrealizedPnl).toBeCloseTo(-2.5); // 76.5 − 79 (basis is per contract)
+  });
+
+  test("a short position inverts value and P&L", () => {
+    const p = enrichOptionPosition(raw({ type: "short" }), contract, quote(0.5, 0.85));
+    expect(p.marketValue).toBeCloseTo(-50);
+    expect(p.unrealizedPnl).toBeCloseTo(29); // sold at 79, now worth 50
+  });
+
+  test("no quote → identity only, prices stay null; no contract → identity stays null", () => {
+    const noQuote = enrichOptionPosition(raw(), contract, undefined);
+    expect(noQuote.strikePrice).toBe(86);
+    expect(noQuote.lastPrice).toBeNull();
+    expect(noQuote.unrealizedPnl).toBeNull();
+    const noContract = enrichOptionPosition(raw(), undefined, quote(0.765, 0.85));
+    expect(noContract.strikePrice).toBeNull();
+    expect(noContract.marketValue).toBeCloseTo(76.5);
+  });
+});
+
+describe("withDayChange — options", () => {
+  // Prices ride the enriched position rows themselves — the same rows a poll
+  // serves from cache during an options-API outage.
+  const enriched = (over: Parameters<typeof raw>[0] = {}) =>
+    enrichOptionPosition(raw(over), contract, quote(0.765, 0.85));
+
+  test("contracts held overnight move from the prior close × multiplier", () => {
+    const p = withDayChange(portfolio(1000), [], new Map(), [
+      enriched({ intradayQuantity: 0, quantity: 2 }),
+    ]);
+    expect(p.dayChange).toBeCloseTo(-17); // (0.765 − 0.85) × 100 × 2
+    expect(p.dayChangePct).toBeCloseTo(-17 / 1017);
+  });
+
+  test("contracts opened today move from their own basis; a short inverts", () => {
+    // 1 contract, opened today at $79
+    const today = withDayChange(portfolio(1000), [], new Map(), [enriched()]);
+    expect(today.dayChange).toBeCloseTo(-2.5); // 76.5 − 79, NOT vs. the 0.85 close
+
+    const short = withDayChange(portfolio(1000), [], new Map(), [
+      enriched({ type: "short", intradayQuantity: 0 }),
+    ]);
+    expect(short.dayChange).toBeCloseTo(8.5);
+  });
+
+  test("a cached (already-enriched) position still counts with no live quote in sight", () => {
+    // The outage path serves enriched rows from cache; Today must not drop them.
+    const p = withDayChange(portfolio(1000), [], new Map(), [
+      enriched({ intradayQuantity: 0, quantity: 2 }),
+    ]);
+    expect(p.dayChange).not.toBeNull();
+  });
+
+  test("a never-priced position is skipped, leaving null when nothing else counts", () => {
+    const p = withDayChange(portfolio(1000), [], new Map(), [raw()]);
+    expect(p.dayChange).toBeNull();
+  });
+});

--- a/app/src/main/services/broker/order-notify.test.ts
+++ b/app/src/main/services/broker/order-notify.test.ts
@@ -132,3 +132,65 @@ describe("orderNotification", () => {
     expect(n.body).toBe("BUY 0.880592 AAPL — filled at $85.18");
   });
 });
+
+describe("orderNotification — options", () => {
+  const tltFill = order({
+    id: "o1",
+    assetType: "option",
+    symbol: "TLT",
+    side: "buy",
+    type: "limit",
+    state: "filled",
+    quantity: 1,
+    cumulativeQuantity: 1,
+    avgPrice: 0.79,
+    limitPrice: 0.79,
+    multiplier: 100,
+    legs: [
+      {
+        optionId: "x",
+        side: "buy",
+        positionEffect: "open",
+        ratioQuantity: 1,
+        contract: {
+          optionId: "x",
+          chainSymbol: "TLT",
+          expirationDate: "2026-11-20",
+          strikePrice: 86,
+          optionType: "call",
+          multiplier: 100,
+        },
+      },
+    ],
+  });
+
+  test("a fill names the contract and the per-contract cost (price × multiplier)", () => {
+    const n = orderNotification(tltFill, "citrini");
+    expect(n.title).toBe("citrini — Order filled");
+    expect(n.body).toBe("BUY 1 TLT $86C 11/20/26 — filled at $79");
+  });
+
+  test("a rejected option order carries no price", () => {
+    const n = orderNotification({ ...tltFill, state: "rejected", avgPrice: null }, null);
+    expect(n.body).toBe("BUY 1 TLT $86C 11/20/26 — rejected");
+  });
+});
+
+describe("orderNotification — crypto", () => {
+  test("coin quantities keep 8 decimals — a 1-satoshi fill is not rounded to 0", () => {
+    const n = orderNotification(
+      order({
+        id: "c1",
+        assetType: "crypto",
+        symbol: "BTC",
+        side: "buy",
+        state: "filled",
+        quantity: 0.00000001,
+        cumulativeQuantity: 0.00000001,
+        avgPrice: 78691.76,
+      }),
+      null,
+    );
+    expect(n.body).toBe("BUY 0.00000001 BTC — filled at $78691.76");
+  });
+});

--- a/app/src/main/services/broker/order-notify.ts
+++ b/app/src/main/services/broker/order-notify.ts
@@ -1,5 +1,6 @@
 import type { OrderStatus } from "@shared/broker";
 import type { HostNotification } from "@shared/notify";
+import { legsLabel, STANDARD_MULTIPLIER } from "@shared/options";
 
 /**
  * RH lifecycle states that are *absorbing* — an order never leaves them. Matched
@@ -51,25 +52,35 @@ function verbFor(state: string | null): string {
   }
 }
 
-/** "2 AAPL" / "$100 AAPL" / "AAPL" — quantity clause of the body. */
+/** "2 AAPL" / "$100 AAPL" / "AAPL" / "1 TLT $86C 11/20/26" — quantity clause of the body. */
 function quantityClause(o: OrderStatus): string {
   const shares = o.cumulativeQuantity ?? o.quantity;
-  const sym = o.symbol ?? "";
-  if (shares != null && shares > 0) return `${trimNum(shares)} ${sym}`.trim();
+  const sym = o.assetType === "option" ? legsLabel(o.legs ?? []) : (o.symbol ?? "");
+  // Coin quantities go far below equity precision — 6 decimals would round a
+  // 1-satoshi (1e-8 BTC) fill to "0 BTC".
+  const decimals = o.assetType === "crypto" ? 8 : 6;
+  if (shares != null && shares > 0) return `${trimNum(shares, decimals)} ${sym}`.trim();
   if (o.dollarAmount != null && o.dollarAmount > 0)
     return `$${trimNum(o.dollarAmount)} ${sym}`.trim();
   return sym || "order";
 }
 
-/** Drop trailing zeros from a fractional quantity/price without losing precision. */
-function trimNum(n: number): string {
-  return Number(n.toFixed(6)).toString();
+/** Drop trailing zeros from a fractional quantity/price without losing precision.
+ *  String-trimmed (not round-tripped through Number) so tiny coin quantities render
+ *  as "0.00000001", never scientific notation. */
+function trimNum(n: number, decimals = 6): string {
+  return n
+    .toFixed(decimals)
+    .replace(/(\.\d*?)0+$/, "$1")
+    .replace(/\.$/, "");
 }
 
 /**
  * Format an order-execution notification. Body reads like
  * `"BUY 2 AAPL — filled at $182.34"`; price is included only for fills (via
- * `avgPrice`). Title is `"<agent> — Order filled"`.
+ * `avgPrice`). An option fill quotes the per-contract cost (`$79.00`, the
+ * per-share price × multiplier — what the account was actually debited per
+ * contract). Title is `"<agent> — Order filled"`.
  */
 export function orderNotification(
   o: OrderStatus,
@@ -78,7 +89,13 @@ export function orderNotification(
 ): HostNotification {
   const verb = verbFor(o.state);
   const side = o.side ? o.side.toUpperCase() : "ORDER";
-  const priced = verb === "filled" && o.avgPrice != null ? ` at $${trimNum(o.avgPrice)}` : "";
+  const perUnit =
+    o.avgPrice == null
+      ? null
+      : o.assetType === "option"
+        ? o.avgPrice * (o.multiplier ?? STANDARD_MULTIPLIER)
+        : o.avgPrice;
+  const priced = verb === "filled" && perUnit != null ? ` at $${trimNum(perUnit)}` : "";
   return {
     kind: "order",
     title: `${agentName ?? "agent"} — Order ${verb}`,

--- a/app/src/main/services/broker/robinhood/client.ts
+++ b/app/src/main/services/broker/robinhood/client.ts
@@ -4,17 +4,34 @@ import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { InvalidGrantError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
-import type { Account, OrderStatus, Portfolio, Position, Quote } from "@shared/broker";
+import type {
+  Account,
+  CryptoPosition,
+  CryptoQuote,
+  OptionContract,
+  OptionPosition,
+  OptionQuote,
+  OrderStatus,
+  Portfolio,
+  Position,
+  Quote,
+} from "@shared/broker";
 import type { Db } from "../../../db/client";
 import { type BrokerAdapter, ConnectSuperseded, type McpServerConfig } from "../adapter";
 import {
   mapAccounts,
+  mapCryptoOrderStatuses,
+  mapCryptoPositions,
+  mapCryptoQuotes,
+  mapOptionInstruments,
+  mapOptionOrderStatuses,
+  mapOptionPositions,
+  mapOptionQuotes,
   mapOrderStatuses,
   mapPortfolio,
   mapPositions,
   mapQuotes,
   nextCursor,
-  RH_ORDER_TOOLS,
   RH_TOOLS,
   unwrap,
 } from "./mapping";
@@ -327,8 +344,82 @@ export class RobinhoodAdapter implements BrokerAdapter {
     return mapQuotes(await this.call(RH_TOOLS.getEquityQuotes, { symbols }));
   }
 
-  orderToolNames(): string[] {
-    return RH_ORDER_TOOLS;
+  // ---- options ----
+
+  async getOptionOrders(
+    accountNumber: string,
+    opts: { createdAtGte?: string; cursor?: string } = {},
+  ): Promise<{ orders: OrderStatus[]; cursor: string | null }> {
+    // As with equities: no `placed_agent` filter, so manual RH-app orders show too.
+    const args: Record<string, unknown> = { account_number: accountNumber };
+    if (opts.createdAtGte) args.created_at_gte = opts.createdAtGte;
+    if (opts.cursor) args.cursor = opts.cursor;
+    const payload = await this.call(RH_TOOLS.getOptionOrders, args);
+    return { orders: mapOptionOrderStatuses(payload), cursor: nextCursor(payload) };
+  }
+
+  async getOptionOrder(accountNumber: string, orderId: string): Promise<OrderStatus | null> {
+    const payload = await this.call(RH_TOOLS.getOptionOrders, {
+      account_number: accountNumber,
+      order_id: orderId,
+    });
+    return mapOptionOrderStatuses(payload)[0] ?? null;
+  }
+
+  async getOptionPositions(accountNumber: string): Promise<OptionPosition[]> {
+    return mapOptionPositions(
+      await this.call(RH_TOOLS.getOptionPositions, {
+        account_number: accountNumber,
+        nonzero: true,
+      }),
+    );
+  }
+
+  async getOptionContracts(optionIds: string[]): Promise<OptionContract[]> {
+    if (optionIds.length === 0) return [];
+    // `ids` is comma-separated; the tool takes a whole batch in one call.
+    return mapOptionInstruments(
+      await this.call(RH_TOOLS.getOptionInstruments, { ids: optionIds.join(",") }),
+    );
+  }
+
+  async getOptionQuotes(optionIds: string[]): Promise<OptionQuote[]> {
+    if (optionIds.length === 0) return [];
+    return mapOptionQuotes(
+      await this.call(RH_TOOLS.getOptionQuotes, { instrument_ids: optionIds }),
+    );
+  }
+
+  // ---- crypto (keyed by the numeric rhs account number) ----
+
+  async getCryptoOrders(
+    rhsAccountNumber: string,
+    opts: { createdAtGte?: string; cursor?: string } = {},
+  ): Promise<{ orders: OrderStatus[]; cursor: string | null }> {
+    const args: Record<string, unknown> = { rhs_account_number: rhsAccountNumber };
+    if (opts.createdAtGte) args.created_at_gte = opts.createdAtGte;
+    if (opts.cursor) args.cursor = opts.cursor;
+    const payload = await this.call(RH_TOOLS.getCryptoOrders, args);
+    return { orders: mapCryptoOrderStatuses(payload), cursor: nextCursor(payload) };
+  }
+
+  async getCryptoOrder(rhsAccountNumber: string, orderId: string): Promise<OrderStatus | null> {
+    const payload = await this.call(RH_TOOLS.getCryptoOrders, {
+      rhs_account_number: rhsAccountNumber,
+      order_id: orderId,
+    });
+    return mapCryptoOrderStatuses(payload)[0] ?? null;
+  }
+
+  async getCryptoPositions(rhsAccountNumber: string): Promise<CryptoPosition[]> {
+    return mapCryptoPositions(
+      await this.call(RH_TOOLS.getCryptoPositions, { rhs_account_number: rhsAccountNumber }),
+    );
+  }
+
+  async getCryptoQuotes(pairSymbols: string[]): Promise<CryptoQuote[]> {
+    if (pairSymbols.length === 0) return [];
+    return mapCryptoQuotes(await this.call(RH_TOOLS.getCryptoQuotes, { symbols: pairSymbols }));
   }
 
   mcpServerConfig(): { name: string; config: McpServerConfig } {

--- a/app/src/main/services/broker/robinhood/mapping.test.ts
+++ b/app/src/main/services/broker/robinhood/mapping.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
   mapAccounts,
+  mapCryptoOrderStatuses,
+  mapCryptoPositions,
+  mapCryptoQuotes,
+  mapOptionInstruments,
+  mapOptionOrderStatuses,
+  mapOptionPositions,
+  mapOptionQuotes,
   mapOrderStatuses,
   mapPortfolio,
   mapPositions,
@@ -57,6 +64,7 @@ describe("mapAccounts", () => {
     expect(accounts).toHaveLength(2);
     expect(accounts[0]).toEqual({
       accountNumber: "991422569",
+      rhsAccountNumber: "991422569",
       type: "individual",
       agentic: false,
       isDefault: true,
@@ -88,6 +96,8 @@ describe("mapPortfolio", () => {
       cash: 1874.6,
       dayChange: null,
       dayChangePct: null,
+      optionsValue: null,
+      cryptoValue: null,
     });
   });
 });
@@ -169,6 +179,7 @@ describe("mapOrderStatuses", () => {
   test("takes avg_price as VWAP and cumulative_quantity as executed — NOT limit/ordered", () => {
     const [o] = mapOrderStatuses({ data: { orders: [filledLimit] } });
     expect(o).toEqual({
+      assetType: "equity",
       id: "6a2c9cb7-a947-4f2d-8771-00c5f3f68b6f",
       symbol: "INTC",
       side: "buy",
@@ -269,5 +280,379 @@ describe("mapQuotes", () => {
       bidPrice: 125.21,
       askPrice: 125.42,
     });
+  });
+});
+
+// ---- options: real shapes from the live MCP (2026-08-27) ----
+
+const TLT_ID = "e9c444cc-5ccc-4dfe-8fd9-64daf22d6338";
+
+const liveOptionOrder = {
+  id: "6a908e72-e3e6-451f-b9bc-e765a26c5056",
+  chain_id: "644f21f0-a166-4c94-bd67-02568d3a5940",
+  chain_symbol: "TLT",
+  state: "filled",
+  type: "limit",
+  trigger: "immediate",
+  direction: "debit",
+  quantity: "1.00000",
+  processed_quantity: "1.00000",
+  pending_quantity: "0.00000",
+  canceled_quantity: "0.00000",
+  price: "0.79000000",
+  stop_price: null,
+  premium: "79.00000000",
+  processed_premium: "79",
+  trade_value_multiplier: "100.0000",
+  time_in_force: "gfd",
+  market_hours: "regular_hours",
+  opening_strategy: "long_call",
+  closing_strategy: null,
+  placed_agent: "agentic",
+  created_at: "2026-08-27T19:22:26.187483Z",
+  updated_at: "2026-08-27T19:22:26.624039Z",
+  last_transaction_at: null,
+  is_replaceable: false,
+  legs: [
+    {
+      id: "de66ccba-fd05-47a4-8e11-dc3510c45a05",
+      option_id: TLT_ID,
+      side: "buy",
+      position_effect: "open",
+      ratio_quantity: 1,
+      expiration_date: "2026-11-20",
+      strike_price: "86.0000",
+      option_type: "call",
+      executions: [
+        {
+          id: "6a908e72-ac36-46ae-a2c3-042f1fb9ef22",
+          price: "0.79000000",
+          quantity: "1.00000",
+          settlement_date: "2026-08-28",
+          trade_date: "2026-08-27",
+          timestamp: "2026-08-27T19:22:26.462000Z",
+        },
+      ],
+    },
+  ],
+};
+
+describe("mapOptionOrderStatuses", () => {
+  test("maps the live single-leg order in per-contract/per-share units with its contract", () => {
+    const [o] = mapOptionOrderStatuses({ data: { orders: [liveOptionOrder] } });
+    expect(o.id).toBe("6a908e72-e3e6-451f-b9bc-e765a26c5056");
+    expect(o.assetType).toBe("option");
+    expect(o.symbol).toBe("TLT"); // chain_symbol — the underlying
+    expect(o.side).toBe("buy"); // the single leg's side, not the net direction
+    expect(o.direction).toBe("debit");
+    expect(o.type).toBe("limit");
+    expect(o.state).toBe("filled");
+    expect(o.quantity).toBe(1);
+    expect(o.cumulativeQuantity).toBe(1);
+    expect(o.limitPrice).toBe(0.79);
+    expect(o.avgPrice).toBe(0.79); // processed_premium / (contracts × multiplier)
+    expect(o.multiplier).toBe(100);
+    expect(o.premium).toBe(79);
+    expect(o.processedPremium).toBe(79);
+    expect(o.strategy).toBe("long_call");
+    expect(o.dollarAmount).toBeNull();
+    expect(o.lastTransactionAt).toBe("2026-08-27T19:22:26.624039Z"); // updated_at fallback
+    expect(o.legs).toHaveLength(1);
+    expect(o.legs?.[0]).toEqual({
+      optionId: TLT_ID,
+      side: "buy",
+      positionEffect: "open",
+      ratioQuantity: 1,
+      contract: {
+        optionId: TLT_ID,
+        chainSymbol: "TLT",
+        expirationDate: "2026-11-20",
+        strikePrice: 86,
+        optionType: "call",
+        multiplier: 100,
+      },
+    });
+  });
+
+  test("a spread's side is its net direction; an unfilled order has no avg price", () => {
+    const [o] = mapOptionOrderStatuses({
+      data: {
+        orders: [
+          {
+            ...liveOptionOrder,
+            state: "queued",
+            processed_quantity: "0.00000",
+            processed_premium: "0",
+            legs: [
+              { ...liveOptionOrder.legs[0], executions: [] },
+              {
+                ...liveOptionOrder.legs[0],
+                option_id: "x",
+                side: "sell",
+                strike_price: "90.0000",
+                executions: [],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(o.side).toBe("debit");
+    expect(o.cumulativeQuantity).toBe(0);
+    expect(o.avgPrice).toBeNull();
+    expect(o.legs?.[1].contract?.strikePrice).toBe(90);
+  });
+
+  test("falls back to the legs' execution VWAP when premium fields are absent", () => {
+    const { premium: _p, processed_premium: _pp, ...noPremium } = liveOptionOrder;
+    const [o] = mapOptionOrderStatuses({ data: { orders: [noPremium] } });
+    expect(o.avgPrice).toBe(0.79);
+  });
+
+  test("empty response yields no orders", () => {
+    expect(mapOptionOrderStatuses({ data: { orders: [] } })).toEqual([]);
+  });
+});
+
+describe("mapOptionPositions", () => {
+  test("maps the live position; average_price stays per contract (multiplier in)", () => {
+    const [p] = mapOptionPositions({
+      data: {
+        positions: [
+          {
+            option_id: TLT_ID,
+            chain_id: "644f21f0-a166-4c94-bd67-02568d3a5940",
+            chain_symbol: "TLT",
+            type: "long",
+            quantity: "1.0000",
+            average_price: "79.0000",
+            expiration_date: "2026-11-20",
+            trade_value_multiplier: "100.0000",
+            intraday_average_open_price: "79.0000",
+            intraday_quantity: "1.0000",
+            pending_buy_quantity: "0.0000",
+            pending_sell_quantity: "0.0000",
+            pending_exercise_quantity: "0.0000",
+            pending_assignment_quantity: "0.0000",
+            pending_expiration_quantity: "1.0000",
+            opened_at: "2026-08-27T19:22:26.260113Z",
+          },
+        ],
+      },
+    });
+    expect(p).toEqual({
+      optionId: TLT_ID,
+      chainId: "644f21f0-a166-4c94-bd67-02568d3a5940",
+      chainSymbol: "TLT",
+      type: "long",
+      quantity: 1,
+      intradayQuantity: 1,
+      averagePrice: 79,
+      intradayAverageOpenPrice: 79,
+      expirationDate: "2026-11-20",
+      multiplier: 100,
+      strikePrice: null, // not in the response — resolved via get_option_instruments
+      optionType: null,
+      lastPrice: null, // no price either — folded in from a quote
+      previousClose: null,
+      marketValue: null,
+      unrealizedPnl: null,
+      pendingQuantity: 1, // exercise + assignment + expiration
+    });
+  });
+});
+
+test("mapOptionInstruments resolves an option_id to its contract", () => {
+  const [c] = mapOptionInstruments({
+    data: {
+      instruments: [
+        {
+          id: TLT_ID,
+          chain_id: "644f21f0-a166-4c94-bd67-02568d3a5940",
+          chain_symbol: "TLT",
+          underlying_type: "equity",
+          expiration_date: "2026-11-20",
+          sellout_datetime: "2026-11-20T20:45:00+00:00",
+          strike_price: "86.0000",
+          type: "call",
+          state: "active",
+          tradability: "tradable",
+          trade_value_multiplier: "100.0000",
+          min_ticks: { above_tick: "0.05", below_tick: "0.01", cutoff_price: "3.00" },
+        },
+      ],
+    },
+  });
+  expect(c).toEqual({
+    optionId: TLT_ID,
+    chainSymbol: "TLT",
+    expirationDate: "2026-11-20",
+    strikePrice: 86,
+    optionType: "call",
+    multiplier: 100,
+  });
+});
+
+describe("mapOptionQuotes", () => {
+  const liveQuote = {
+    quote: {
+      instrument_id: TLT_ID,
+      ask_price: "0.770000",
+      ask_size: 1,
+      bid_price: "0.760000",
+      bid_size: 123,
+      break_even_price: "86.770000",
+      adjusted_mark_price: "0.770000",
+      mark_price: "0.765000",
+      previous_close_price: "0.850000",
+      previous_close_date: "2026-08-26",
+      implied_volatility: "0.099614",
+      delta: "0.308245",
+      gamma: "0.088061",
+      theta: "-0.010901",
+      vega: "0.141183",
+      open_interest: 28428,
+      volume: 259,
+      updated_at: "2026-08-27T19:46:28.647347216Z",
+    },
+    close: {
+      instrument_id: TLT_ID,
+      symbol: "TLT",
+      date: "2026-08-26",
+      price: "0.85",
+      interpolated: false,
+      source: "ddb-market-snapshot",
+    },
+  };
+
+  test("mark from mark_price, prior close from the official close", () => {
+    const [q] = mapOptionQuotes({ data: { results: [liveQuote] } });
+    expect(q).toEqual({
+      optionId: TLT_ID,
+      mark: 0.765,
+      bidPrice: 0.76,
+      askPrice: 0.77,
+      previousClose: 0.85,
+      impliedVolatility: 0.099614,
+      delta: 0.308245,
+      theta: -0.010901,
+    });
+  });
+
+  test("falls back to the quote's previous_close_price when the close is missing", () => {
+    const [q] = mapOptionQuotes({ data: { results: [{ quote: liveQuote.quote }] } });
+    expect(q.previousClose).toBe(0.85);
+  });
+});
+
+// ---- crypto ----
+
+describe("mapCryptoQuotes", () => {
+  // Real shape from live get_crypto_quotes (2026-08-31): symbol comes back
+  // UNhyphenated; open_price is the prior midnight-ET close.
+  const liveQuote = {
+    symbol: "BTCUSD",
+    id: "3d961844-d360-45fc-989b-f6fca761d511",
+    bid_price: "77951.48703514",
+    bid_time: "2026-08-31T18:39:00.037-04:00",
+    ask_price: "79432.03469233",
+    ask_time: "2026-08-31T18:39:01.544-04:00",
+    mark_price: "78691.760863735",
+    open_price: "77747.085",
+    routing: "Market Maker Routing",
+    updated_at: "2026-08-31T18:39:01.63-04:00",
+  };
+
+  test("maps the live shape: mark, bid/ask, open_price as the previous close", () => {
+    const [q] = mapCryptoQuotes({ data: { results: [liveQuote] } });
+    expect(q.symbol).toBe("BTCUSD");
+    expect(q.mark).toBeCloseTo(78691.760863735);
+    expect(q.bidPrice).toBeCloseTo(77951.48703514);
+    expect(q.askPrice).toBeCloseTo(79432.03469233);
+    expect(q.previousClose).toBeCloseTo(77747.085);
+  });
+});
+
+describe("mapCryptoPositions", () => {
+  // Constructed from the tool's documented field guide (the live account held no
+  // crypto when this was written) — verify against a real position when one exists.
+  test("asset from currency.code; avg cost from summed direct cost bases", () => {
+    const [p] = mapCryptoPositions({
+      data: {
+        results: [
+          {
+            currency: { code: "BTC" },
+            quantity: "0.003",
+            quantity_transferable: "0.002",
+            intraday_quantity: "0.001",
+            cost_bases: [
+              { direct_cost_basis: "160.00", direct_quantity: "0.002" },
+              { direct_cost_basis: "0", direct_quantity: "0" },
+            ],
+          },
+        ],
+      },
+    });
+    expect(p.assetCode).toBe("BTC");
+    expect(p.quantity).toBe(0.003);
+    expect(p.transferableQuantity).toBe(0.002);
+    expect(p.avgCost).toBeCloseTo(80000); // $160 over 0.002 BTC — direct buys only
+    expect(p.directQuantity).toBe(0.002); // the other 0.001 has no captured basis
+    expect(p.intradayQuantity).toBe(0.001);
+    expect(p.lastPrice).toBeNull(); // no price in the response — folded from quotes
+  });
+
+  test("no cost bases → no average, never NaN", () => {
+    const [p] = mapCryptoPositions({
+      data: { results: [{ currency: { code: "DOGE" }, quantity: "100" }] },
+    });
+    expect(p.avgCost).toBeNull();
+    expect(p.directQuantity).toBeNull();
+  });
+});
+
+describe("mapCryptoOrderStatuses", () => {
+  // Constructed from the tool's documented response guide — verify against the
+  // first real gated crypto order (TODO.md).
+  test("maps onto the shared OrderStatus in coin units", () => {
+    const [o] = mapCryptoOrderStatuses({
+      data: {
+        rhs_account_number: "547526228",
+        results: [
+          {
+            id: "order-1",
+            currency_code: "BTC",
+            currency_pair_id: "3d961844-d360-45fc-989b-f6fca761d511",
+            side: "buy",
+            type: "limit",
+            state: "filled",
+            state_group: "closed",
+            quantity: "0.00127",
+            cumulative_quantity: "0.00127",
+            average_price: "78650.00",
+            limit_price: "78700.00",
+            fee: "0.45",
+            initiator_type: "agent",
+            created_at: "2026-08-31T18:00:00Z",
+            updated_at: "2026-08-31T18:00:05Z",
+          },
+        ],
+      },
+    });
+    expect(o.id).toBe("order-1");
+    expect(o.assetType).toBe("crypto");
+    expect(o.symbol).toBe("BTC");
+    expect(o.side).toBe("buy");
+    expect(o.state).toBe("filled");
+    expect(o.quantity).toBe(0.00127);
+    expect(o.cumulativeQuantity).toBe(0.00127);
+    expect(o.avgPrice).toBe(78650);
+    expect(o.limitPrice).toBe(78700);
+    expect(o.fees).toBe(0.45);
+    expect(o.lastTransactionAt).toBe("2026-08-31T18:00:05Z");
+  });
+
+  test("empty response yields no orders", () => {
+    expect(mapCryptoOrderStatuses({ data: { results: [] } })).toEqual([]);
   });
 });

--- a/app/src/main/services/broker/robinhood/mapping.ts
+++ b/app/src/main/services/broker/robinhood/mapping.ts
@@ -1,4 +1,16 @@
-import type { Account, OrderStatus, Portfolio, Position, Quote } from "@shared/broker";
+import type {
+  Account,
+  CryptoPosition,
+  CryptoQuote,
+  OptionContract,
+  OptionPosition,
+  OptionQuote,
+  OrderStatus,
+  Portfolio,
+  Position,
+  Quote,
+} from "@shared/broker";
+import type { OptionLeg } from "@shared/options";
 
 /**
  * Robinhood Agentic Trading MCP tool names (confirmed live, 2026-06-11) and
@@ -13,18 +25,18 @@ export const RH_TOOLS = {
   getEquityPositions: "get_equity_positions",
   getEquityOrders: "get_equity_orders",
   getEquityQuotes: "get_equity_quotes",
+  getOptionOrders: "get_option_orders",
+  getOptionPositions: "get_option_positions",
+  getOptionInstruments: "get_option_instruments",
+  getOptionQuotes: "get_option_quotes",
+  getCryptoOrders: "get_crypto_orders",
+  getCryptoPositions: "get_crypto_positions",
+  getCryptoQuotes: "get_crypto_quotes",
   placeEquityOrder: "place_equity_order",
   placeOptionOrder: "place_option_order",
   cancelEquityOrder: "cancel_equity_order",
   cancelOptionOrder: "cancel_option_order",
 } as const;
-
-export const RH_ORDER_TOOLS = [
-  RH_TOOLS.placeEquityOrder,
-  RH_TOOLS.placeOptionOrder,
-  RH_TOOLS.cancelEquityOrder,
-  RH_TOOLS.cancelOptionOrder,
-];
 
 type McpResult = { content?: Array<{ type: string; text?: string }> };
 
@@ -66,6 +78,8 @@ function asArray(payload: unknown, ...keys: string[]): unknown[] {
 export function mapAccounts(payload: unknown): Account[] {
   return asArray(payload, "accounts").map((a) => ({
     accountNumber: String(pick(a, "account_number", "rhs_account_number") ?? ""),
+    // The numeric brokerage id crypto tools key on (usually equal to account_number).
+    rhsAccountNumber: (pick(a, "rhs_account_number") as string) ?? null,
     type: String(pick(a, "brokerage_account_type", "type") ?? ""),
     agentic: Boolean(pick(a, "agentic_allowed")),
     isDefault: Boolean(pick(a, "is_default")),
@@ -91,6 +105,8 @@ export function mapPortfolio(payload: unknown, accountNumber: string): Portfolio
     // Day change isn't in get_portfolio — the poller derives it from quotes.
     dayChange: null,
     dayChangePct: null,
+    optionsValue: num(pick(data, "options_value")),
+    cryptoValue: num(pick(data, "crypto_value")),
   };
 }
 
@@ -128,6 +144,7 @@ export function mapOrderStatus(o: unknown): OrderStatus {
   const dollar = pick(o, "dollar_based_amount");
   return {
     id: String(pick(o, "id", "order_id") ?? ""),
+    assetType: "equity",
     symbol: (pick(o, "symbol", "chain_symbol") as string) ?? null,
     side: (pick(o, "side", "direction") as string) ?? null,
     type: (pick(o, "type", "order_type") as string) ?? null,
@@ -184,4 +201,276 @@ export function mapQuotes(payload: unknown): Quote[] {
       bidPrice: num(pick(q, "bid_price", "bid")),
     };
   });
+}
+
+// ---- options ----
+
+/**
+ * Map a `get_option_orders` envelope onto the same `OrderStatus` the equity ledger
+ * uses, in per-contract/per-share units. Verified against the live response
+ * (2026-08-27): `quantity`/`processed_quantity` are contracts, `price` is the limit
+ * per share, `premium`/`processed_premium` are net dollars for the whole order, and
+ * each leg carries the contract's expiry/strike/type — so the ledger alone can name
+ * every contract an order touched, with no instrument lookup.
+ */
+export function mapOptionOrderStatuses(payload: unknown): OrderStatus[] {
+  return asArray(payload, "orders", "option_orders").map(mapOptionOrderStatus);
+}
+
+export function mapOptionOrderStatus(o: unknown): OrderStatus {
+  const chainSymbol = (pick(o, "chain_symbol") as string) ?? null;
+  const multiplier = num(pick(o, "trade_value_multiplier"));
+  const legs = mapOrderLegs(pick(o, "legs"), chainSymbol, multiplier);
+  const processedQty = num(pick(o, "processed_quantity", "cumulative_quantity"));
+  const processedPremium = num(pick(o, "processed_premium"));
+  // Executed price per share: net premium over executed contracts (correct for a
+  // spread too), else the legs' execution VWAP (a single leg with no premium field).
+  let avgPrice: number | null = null;
+  if (processedPremium != null && processedQty && multiplier) {
+    avgPrice = processedPremium / (processedQty * multiplier);
+  } else {
+    avgPrice = executionsVwap(pick(o, "legs"));
+  }
+  const direction = (pick(o, "direction") as string) ?? null;
+  return {
+    id: String(pick(o, "id", "order_id") ?? ""),
+    assetType: "option",
+    symbol: chainSymbol,
+    // A single leg has a real side; a spread only has a net direction.
+    side: legs.length === 1 ? legs[0].side : direction,
+    type: (pick(o, "type", "order_type") as string) ?? null,
+    state: (pick(o, "state", "status") as string) ?? null,
+    quantity: num(pick(o, "quantity")),
+    cumulativeQuantity: processedQty,
+    avgPrice,
+    limitPrice: num(pick(o, "price", "limit_price")),
+    fees: num(pick(o, "fees")),
+    dollarAmount: null,
+    createdAt: (pick(o, "created_at") as string) ?? null,
+    // RH sends `last_transaction_at: null` even on a filled option order (verified
+    // live), so fall through to `updated_at` on null, not just on absence.
+    lastTransactionAt:
+      (pick(o, "last_transaction_at") as string | null) ??
+      (pick(o, "updated_at") as string | null) ??
+      null,
+    multiplier,
+    direction,
+    strategy:
+      (pick(o, "opening_strategy") as string) ?? (pick(o, "closing_strategy") as string) ?? null,
+    legs,
+    premium: num(pick(o, "premium")),
+    processedPremium,
+  };
+}
+
+function mapOrderLegs(
+  raw: unknown,
+  chainSymbol: string | null,
+  multiplier: number | null,
+): OptionLeg[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((l) => {
+    const optionId = String(pick(l, "option_id", "option") ?? "");
+    const type = low(pick(l, "option_type", "type"));
+    const contract: OptionContract = {
+      optionId,
+      chainSymbol,
+      expirationDate: (pick(l, "expiration_date") as string) ?? null,
+      strikePrice: num(pick(l, "strike_price")),
+      optionType: type === "call" || type === "put" ? type : null,
+      multiplier,
+    };
+    return {
+      optionId,
+      side: low(pick(l, "side")),
+      positionEffect: low(pick(l, "position_effect")),
+      ratioQuantity: num(pick(l, "ratio_quantity")),
+      contract,
+    };
+  });
+}
+
+/** Volume-weighted average of every execution across the legs, per share. */
+function executionsVwap(legs: unknown): number | null {
+  if (!Array.isArray(legs)) return null;
+  let notional = 0;
+  let qty = 0;
+  for (const l of legs) {
+    const ex = pick(l, "executions");
+    if (!Array.isArray(ex)) continue;
+    for (const e of ex) {
+      const p = num(pick(e, "price"));
+      const q = num(pick(e, "quantity"));
+      if (p == null || q == null) continue;
+      notional += p * q;
+      qty += q;
+    }
+  }
+  return qty > 0 ? notional / qty : null;
+}
+
+/**
+ * `get_option_positions` → OptionPosition[]. Positions carry no strike/type (RH:
+ * "look up via get_option_instruments") and no price — the poller folds in the
+ * resolved contract and a quote. `average_price` is per contract, multiplier
+ * included (`79` for a $0.79 contract), and is kept in those units.
+ */
+export function mapOptionPositions(payload: unknown): OptionPosition[] {
+  return asArray(payload, "positions", "option_positions").map((p) => ({
+    optionId: String(pick(p, "option_id", "option") ?? ""),
+    chainId: (pick(p, "chain_id") as string) ?? null,
+    chainSymbol: String(pick(p, "chain_symbol", "symbol") ?? ""),
+    type: low(pick(p, "type")),
+    quantity: num(pick(p, "quantity")) ?? 0,
+    intradayQuantity: num(pick(p, "intraday_quantity")),
+    averagePrice: num(pick(p, "average_price")),
+    intradayAverageOpenPrice: num(pick(p, "intraday_average_open_price")),
+    expirationDate: (pick(p, "expiration_date") as string) ?? null,
+    multiplier: num(pick(p, "trade_value_multiplier")),
+    strikePrice: null,
+    optionType: null,
+    lastPrice: null,
+    previousClose: null,
+    marketValue: null,
+    unrealizedPnl: null,
+    pendingQuantity: sumNums(
+      pick(p, "pending_exercise_quantity"),
+      pick(p, "pending_assignment_quantity"),
+      pick(p, "pending_expiration_quantity"),
+    ),
+  }));
+}
+
+/** `get_option_instruments` → the contract identity behind each `option_id`. */
+export function mapOptionInstruments(payload: unknown): OptionContract[] {
+  return asArray(payload, "instruments", "results").map((i) => {
+    const type = low(pick(i, "type", "option_type"));
+    return {
+      optionId: String(pick(i, "id", "option_id") ?? ""),
+      chainSymbol: (pick(i, "chain_symbol") as string) ?? null,
+      expirationDate: (pick(i, "expiration_date") as string) ?? null,
+      strikePrice: num(pick(i, "strike_price")),
+      optionType: type === "call" || type === "put" ? type : null,
+      multiplier: num(pick(i, "trade_value_multiplier")),
+    };
+  });
+}
+
+/**
+ * `get_option_quotes` → per-share quotes. Like equity quotes, each result pairs the
+ * live `quote` with an official prior-session `close`; the close is preferred as the
+ * day-change reference (RH's guide), falling back to `previous_close_price`.
+ */
+export function mapOptionQuotes(payload: unknown): OptionQuote[] {
+  return asArray(payload, "results", "quotes").map((r) => {
+    const q = (pick(r, "quote") ?? r) as unknown;
+    const close = pick(r, "close");
+    return {
+      optionId: String(pick(q, "instrument_id", "option_id", "id") ?? ""),
+      mark: num(pick(q, "mark_price", "adjusted_mark_price", "last_trade_price")),
+      bidPrice: num(pick(q, "bid_price")),
+      askPrice: num(pick(q, "ask_price")),
+      previousClose: num(pick(close, "price")) ?? num(pick(q, "previous_close_price")),
+      impliedVolatility: num(pick(q, "implied_volatility")),
+      delta: num(pick(q, "delta")),
+      theta: num(pick(q, "theta")),
+    };
+  });
+}
+
+// ---- crypto ----
+
+/**
+ * `get_crypto_orders` → the shared `OrderStatus`, `assetType: "crypto"`. Quantities
+ * are coins, prices per coin. Field names follow the tool's documented response
+ * (`currency_code`, `cumulative_quantity`, `average_price` VWAP, `fee`,
+ * `state_group`); the envelope key is `results`. Built before a live order existed
+ * on this account — verify against the first real gated crypto order (TODO.md).
+ */
+export function mapCryptoOrderStatuses(payload: unknown): OrderStatus[] {
+  return asArray(payload, "results", "orders").map((o) => {
+    const dollar = pick(o, "dollar_based_amount", "dollar_amount");
+    return {
+      id: String(pick(o, "id", "order_id") ?? ""),
+      assetType: "crypto" as const,
+      symbol: (pick(o, "currency_code", "symbol") as string) ?? null,
+      side: (pick(o, "side") as string) ?? null,
+      type: (pick(o, "type", "order_type") as string) ?? null,
+      state: (pick(o, "state", "status") as string) ?? null,
+      quantity: num(pick(o, "quantity")),
+      cumulativeQuantity: num(pick(o, "cumulative_quantity", "filled_quantity")),
+      avgPrice: num(pick(o, "average_price")),
+      limitPrice: num(pick(o, "limit_price", "price")),
+      fees: num(pick(o, "fee", "fees")),
+      dollarAmount:
+        dollar && typeof dollar === "object" ? num(pick(dollar, "amount")) : num(dollar),
+      createdAt: (pick(o, "created_at") as string) ?? null,
+      lastTransactionAt:
+        (pick(o, "last_transaction_at") as string | null) ??
+        (pick(o, "updated_at") as string | null) ??
+        null,
+    };
+  });
+}
+
+/**
+ * `get_crypto_positions` → CryptoPosition[]. No price in the response (folded in
+ * from quotes at poll time). Per-coin average cost = Σ direct_cost_basis /
+ * Σ direct_quantity across `cost_bases` (multi-entry after forks); transfers and
+ * rewards carry no basis, so `directQuantity` can trail `quantity`.
+ */
+export function mapCryptoPositions(payload: unknown): CryptoPosition[] {
+  return asArray(payload, "results", "positions").map((p) => {
+    const currency = pick(p, "currency");
+    let basis = 0;
+    let directQty = 0;
+    const bases = pick(p, "cost_bases");
+    if (Array.isArray(bases)) {
+      for (const b of bases) {
+        basis += num(pick(b, "direct_cost_basis")) ?? 0;
+        directQty += num(pick(b, "direct_quantity")) ?? 0;
+        // Best-effort intraday portion; exact field names unverified live.
+      }
+    }
+    return {
+      assetCode: String(pick(currency, "code") ?? pick(p, "currency_code", "symbol") ?? ""),
+      quantity: num(pick(p, "quantity")) ?? 0,
+      transferableQuantity: num(pick(p, "quantity_transferable")),
+      avgCost: directQty > 0 ? basis / directQty : null,
+      directQuantity: Array.isArray(bases) ? directQty : null,
+      intradayQuantity: num(pick(p, "intraday_quantity")),
+      lastPrice: null,
+      previousClose: null,
+      marketValue: null,
+      unrealizedPnl: null,
+    };
+  });
+}
+
+/** `get_crypto_quotes` → per-coin quotes; `open_price` is the prior midnight-ET close. */
+export function mapCryptoQuotes(payload: unknown): CryptoQuote[] {
+  return asArray(payload, "results", "quotes").map((q) => ({
+    symbol: String(pick(q, "symbol") ?? ""),
+    mark: num(pick(q, "mark_price")),
+    bidPrice: num(pick(q, "bid_price")),
+    askPrice: num(pick(q, "ask_price")),
+    previousClose: num(pick(q, "open_price", "previous_close_price")),
+  }));
+}
+
+function low(v: unknown): string | null {
+  return typeof v === "string" && v ? v.toLowerCase() : null;
+}
+
+/** Sum of the numeric inputs, ignoring the unparsable; null when none parsed. */
+function sumNums(...vs: unknown[]): number | null {
+  let total = 0;
+  let any = false;
+  for (const v of vs) {
+    const n = num(v);
+    if (n == null) continue;
+    total += n;
+    any = true;
+  }
+  return any ? total : null;
 }

--- a/app/src/main/services/harness/claude.ts
+++ b/app/src/main/services/harness/claude.ts
@@ -11,6 +11,7 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { GATED_TOOL_MATCHER, PREALLOWED_TOOL_PATTERNS } from "@shared/robinhood-tools";
 import { resolveHooksDir } from "../agents/paths";
 import { claudeConfigHasRobinhood } from "./robinhood-mcp";
 import type { Harness, ProbeResult, SessionMode } from "./types";
@@ -19,9 +20,11 @@ const execFileAsync = promisify(execFile);
 
 /**
  * The agent-dir `.claude/settings.json` that wires Claude Code's order gate: the
- * PreToolUse hook on the four order tools (→ `approval-gate.sh`, the approval card),
+ * PreToolUse hook on the money-moving tools (→ `approval-gate.sh`, the approval card),
  * the PostToolUse order-result capture, and the Notification/Stop status hooks, plus
- * the read-only-tool allowlist. Generated IN CODE (not copied from the template): the
+ * the allowlist for reads and cosmetic writes. The matcher and allowlist derive from
+ * the classification table in `@shared/robinhood-tools` — the single place the gated
+ * set is maintained. Generated IN CODE (not copied from the template): the
  * template's `.claude/settings.json` is git-untracked (`.claude/` is gitignored), so a
  * clean CI release build never bundles it and a template-copy scaffold leaves the agent
  * UNGATED. Emitting it here — and re-emitting before every spawn — makes the gate
@@ -34,18 +37,13 @@ const CLAUDE_SETTINGS_JSON = `${JSON.stringify(
     $schema: "https://json.schemastore.org/claude-code-settings.json",
     enabledMcpjsonServers: ["robinhood", "opentrade"],
     permissions: {
-      allow: [
-        "mcp__robinhood__get_*",
-        "mcp__robinhood__search",
-        "mcp__robinhood__review_*",
-        "mcp__opentrade__*",
-      ],
+      allow: [...PREALLOWED_TOOL_PATTERNS, "mcp__opentrade__*"],
       deny: [],
     },
     hooks: {
       PreToolUse: [
         {
-          matcher: "mcp__robinhood__(place|cancel)_(equity|option)_order",
+          matcher: GATED_TOOL_MATCHER,
           hooks: [
             {
               type: "command",
@@ -57,7 +55,7 @@ const CLAUDE_SETTINGS_JSON = `${JSON.stringify(
       ],
       PostToolUse: [
         {
-          matcher: "mcp__robinhood__(place|cancel)_(equity|option)_order",
+          matcher: GATED_TOOL_MATCHER,
           hooks: [
             { type: "command", command: "$CLAUDE_PROJECT_DIR/.claude/hooks/order-result.sh" },
           ],

--- a/app/src/main/services/harness/codex.ts
+++ b/app/src/main/services/harness/codex.ts
@@ -15,6 +15,7 @@ import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { promisify } from "node:util";
 import type { Agent } from "@shared/agent";
+import { GATED_TOOL_MATCHER, GATED_TOOLS } from "@shared/robinhood-tools";
 import { OPENTRADE_HOME } from "../../db/client";
 import { hostLog } from "../../host/log";
 import { resolveAgentMcp, resolveHooksDir } from "../agents/paths";
@@ -24,16 +25,6 @@ import { codexConfigHasRobinhood, ROBINHOOD_MCP_URL } from "./robinhood-mcp";
 import type { Harness, ProbeResult, SessionMode } from "./types";
 
 const execFileAsync = promisify(execFile);
-/** The four order-placing tools gated by the approval anchor + the hook matcher.
- *  Single source for the codex side of the gate surface (the claude template's
- *  settings.json carries the equivalent matcher as a static string). */
-export const ORDER_TOOLS = [
-  "place_equity_order",
-  "place_option_order",
-  "cancel_equity_order",
-  "cancel_option_order",
-] as const;
-export const ORDER_TOOL_MATCHER = "mcp__robinhood__(place|cancel)_(equity|option)_order";
 
 /** Env keys stripped from a codex background run when subscription auth is enforced
  *  (single source — referenced by both the harness field and the server-env builder
@@ -85,8 +76,9 @@ function surfaceSessionSplit(agent: Agent, detail: string): void {
  * silently drops the TUI into its embedded engine, splitting the session.
  *
  * The order gate is layered fail-closed (spike-verified):
- *  - anchor: `approval_mode = "prompt"` on the four order tools in the generated
- *    config.toml — codex core raises an elicitation the backend answers through
+ *  - anchor: `approval_mode = "prompt"` on every money-moving tool (the
+ *    `@shared/robinhood-tools` table) in the generated config.toml — codex core
+ *    raises an elicitation the backend answers through
  *    ApprovalService; no answer / client error / disconnect = Decline.
  *    (`"approve"` means PRE-approved in codex — never use it for order tools.)
  *  - redundancy: the same approval-gate.sh PreToolUse hook as claude (codex
@@ -249,7 +241,7 @@ export function createCodexHarness(manager: CodexAppServerManager): Harness {
         hooks: {
           PreToolUse: [
             {
-              matcher: ORDER_TOOL_MATCHER,
+              matcher: GATED_TOOL_MATCHER,
               hooks: [
                 {
                   type: "command",
@@ -261,7 +253,7 @@ export function createCodexHarness(manager: CodexAppServerManager): Harness {
           ],
           PostToolUse: [
             {
-              matcher: ORDER_TOOL_MATCHER,
+              matcher: GATED_TOOL_MATCHER,
               hooks: [
                 {
                   type: "command",
@@ -339,7 +331,7 @@ trust_level = "trusted"
 url = "${ROBINHOOD_MCP_URL}"
 default_tools_approval_mode = "approve"
 
-${ORDER_TOOLS.map((t) => `[mcp_servers.robinhood.tools.${t}]\napproval_mode = "prompt"`).join(
+${GATED_TOOLS.map((t) => `[mcp_servers.robinhood.tools.${t}]\napproval_mode = "prompt"`).join(
   "\n\n",
 )}
 

--- a/app/src/main/services/local-api/index.ts
+++ b/app/src/main/services/local-api/index.ts
@@ -35,6 +35,7 @@ const BIND_RETRY_MS = 300;
  * - Market-data faucet (M2): a pull-through cache over the broker so agents'
  *   Monitor watch-scripts can poll prices/positions without hammering Robinhood:
  *     GET /quotes/:symbol?maxAge=5   GET /positions?maxAge=30
+ *     GET /option-positions?maxAge=30   GET /crypto-positions?maxAge=30
  * - Hook endpoints (M3): the PreToolUse approval gate and the Notification/Stop
  *   status feed, called by the scaffolded hook scripts in each agent folder:
  *     POST /hook/pretool-approval   POST /hook/status
@@ -158,6 +159,14 @@ export class LocalApiServer {
     if (url.pathname === "/positions") {
       const maxAge = (Number(url.searchParams.get("maxAge")) || 30) * 1000;
       return json(res, 200, await this.broker.getPositionsLive(maxAge));
+    }
+    if (url.pathname === "/option-positions") {
+      const maxAge = (Number(url.searchParams.get("maxAge")) || 30) * 1000;
+      return json(res, 200, await this.broker.getOptionPositionsLive(maxAge));
+    }
+    if (url.pathname === "/crypto-positions") {
+      const maxAge = (Number(url.searchParams.get("maxAge")) || 30) * 1000;
+      return json(res, 200, await this.broker.getCryptoPositionsLive(maxAge));
     }
     return json(res, 404, { error: "not found" });
   }

--- a/app/src/main/trpc/routers/broker.ts
+++ b/app/src/main/trpc/routers/broker.ts
@@ -12,6 +12,8 @@ export const brokerRouter = router({
 
   portfolio: publicProcedure.query(({ ctx }) => ctx.broker.getCachedPortfolio()),
   positions: publicProcedure.query(({ ctx }) => ctx.broker.getCachedPositions()),
+  optionPositions: publicProcedure.query(({ ctx }) => ctx.broker.getCachedOptionPositions()),
+  cryptoPositions: publicProcedure.query(({ ctx }) => ctx.broker.getCachedCryptoPositions()),
   /** The agentic order ledger from RH — source of truth for execution status. */
   agenticOrders: publicProcedure.query(({ ctx }) => ctx.broker.getAgenticOrdersCached()),
 

--- a/app/src/renderer/components/panels/Activity.tsx
+++ b/app/src/renderer/components/panels/Activity.tsx
@@ -1,5 +1,6 @@
 import type { AuditEntry, ParsedOrder } from "@shared/approval";
 import type { OrderStatus } from "@shared/broker";
+import { legsLabel, STANDARD_MULTIPLIER } from "@shared/options";
 import { ChevronRight, RefreshCw } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useActivity } from "../../hooks/useActivity";
@@ -358,7 +359,10 @@ interface HeaderView {
 /**
  * The executed cost line from RH's live `OrderStatus`: real cumulative shares @
  * VWAP, never a placement estimate — so a not-yet-filled order shows no numbers.
- * Buy spends cash (−), sell returns cash (+). Shared by group + external rows.
+ * Buy spends cash (−), sell returns cash (+). An option order counts contracts at
+ * a per-share price, so the cost carries the multiplier (`1 contract at $0.79` →
+ * `-$79.00`); a spread's net debit/credit takes the sign from its direction.
+ * Shared by group + external rows.
  */
 function executedNumbers(
   status: OrderStatus | null,
@@ -367,9 +371,24 @@ function executedNumbers(
   const qty = status?.cumulativeQuantity ?? null;
   const price = status?.avgPrice ?? null;
   if (qty != null && qty > 0 && price != null) {
-    const cost = qty * price;
-    const total = signedUsd(side === "buy" ? -cost : cost);
-    const breakdown = `${num(qty, 3)} ${qty === 1 ? "share" : "shares"} at ${usd(price)}`;
+    const isOption = status?.assetType === "option";
+    const isCrypto = status?.assetType === "crypto";
+    const mult = isOption ? (status?.multiplier ?? STANDARD_MULTIPLIER) : 1;
+    const cost = qty * price * mult;
+    const pays = side === "buy" || side === "debit";
+    const total = signedUsd(pays ? -cost : cost);
+    // Units: contracts for options, the asset code for crypto (never "shares" for
+    // coins — RH's own rule), shares otherwise. Coin quantities need more precision.
+    const unit = isOption
+      ? qty === 1
+        ? "contract"
+        : "contracts"
+      : isCrypto
+        ? (status?.symbol ?? "")
+        : qty === 1
+          ? "share"
+          : "shares";
+    const breakdown = `${num(qty, isCrypto ? 8 : 3)} ${unit} at ${usd(price)}`.trim();
     return { total, breakdown };
   }
   return { total: null, breakdown: null };
@@ -391,7 +410,9 @@ function headerView(group: ActivityGroup, status: OrderStatus | null): HeaderVie
 
   if (parsed && parsed.kind === "place") {
     const isLimit = parsed.orderType === "limit" && parsed.limitPrice != null;
-    const action = `${(parsed.side ?? "order").toUpperCase()} ${parsed.symbol ?? "?"} @ ${
+    // An option names its contract (`TLT $86C 11/20/26`) where an equity shows its symbol.
+    const name = parsed.instrument ?? parsed.symbol ?? "?";
+    const action = `${(parsed.side ?? "order").toUpperCase()} ${name} @ ${
       isLimit ? usd(parsed.limitPrice) : "Market"
     }`;
     return { primary: action, ...executedNumbers(status, parsed.side ?? null) };
@@ -403,7 +424,9 @@ function headerView(group: ActivityGroup, status: OrderStatus | null): HeaderVie
 /** Header for an external order, built straight from RH's `OrderStatus`. */
 function externalView(status: OrderStatus): HeaderView {
   const isLimit = status.type === "limit" && status.limitPrice != null;
-  const action = `${(status.side ?? "order").toUpperCase()} ${status.symbol ?? "?"} @ ${
+  const name =
+    status.assetType === "option" ? legsLabel(status.legs ?? []) : (status.symbol ?? "?");
+  const action = `${(status.side ?? "order").toUpperCase()} ${name} @ ${
     isLimit ? usd(status.limitPrice) : "Market"
   }`;
   return { primary: action, ...executedNumbers(status, status.side) };

--- a/app/src/renderer/components/panels/PendingApprovals.tsx
+++ b/app/src/renderer/components/panels/PendingApprovals.tsx
@@ -1,4 +1,5 @@
 import type { Approval } from "@shared/approval";
+import { contractLabel, legActionLabel } from "@shared/options";
 import { Check, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useApprovals } from "../../hooks/useApprovals";
@@ -45,6 +46,18 @@ function PendingCard({ approval }: { approval: Approval }) {
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="text-sm font-medium">{approval.parsed?.summary ?? approval.toolName}</div>
+          {/* A spread's summary names only the underlying + leg count; list the legs. */}
+          {(approval.parsed?.legs?.length ?? 0) > 1 && (
+            <ul className="mt-1 flex flex-col gap-0.5 text-xs text-muted-foreground">
+              {approval.parsed?.legs?.map((leg) => (
+                <li key={leg.optionId}>
+                  {legActionLabel(leg.side, leg.positionEffect)}{" "}
+                  {leg.ratioQuantity && leg.ratioQuantity > 1 ? `${leg.ratioQuantity}× ` : ""}
+                  {contractLabel(leg.contract)}
+                </li>
+              ))}
+            </ul>
+          )}
           <div className="mt-0.5 text-[11px] text-muted-foreground">
             {approval.agentName ?? "agent"} · {approval.toolName}
           </div>

--- a/app/src/renderer/components/panels/Portfolio.tsx
+++ b/app/src/renderer/components/panels/Portfolio.tsx
@@ -1,9 +1,12 @@
-import { Loader2 } from "lucide-react";
+import type { CryptoPosition, OptionPosition } from "@shared/broker";
+import { contractLabel } from "@shared/options";
+import { ChevronRight, Loader2 } from "lucide-react";
+import { useState } from "react";
 import { useBrokerData, useBrokerStatus } from "../../hooks/useBroker";
-import { ago, num, pct, signedUsd, usd } from "../../lib/format";
+import { ago, num, pct, signedPct, signedUsd, usd } from "../../lib/format";
 import { trpc } from "../../lib/trpc";
 import { cn } from "../../lib/utils";
-import { useUIStore } from "../../stores/ui";
+import { type PositionsMetric, useUIStore } from "../../stores/ui";
 import { Button } from "../ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
 
@@ -17,6 +20,9 @@ export function Portfolio() {
   const data = useBrokerData();
   const balancesHidden = useUIStore((s) => s.balancesHidden);
   const toggleBalances = useUIStore((s) => s.toggleBalances);
+  const [equitiesOpen, setEquitiesOpen] = useState(true);
+  const [optionsOpen, setOptionsOpen] = useState(true);
+  const [cryptoOpen, setCryptoOpen] = useState(true);
 
   if (!status || status.status === "disconnected" || status.status === "error") {
     return (
@@ -61,6 +67,8 @@ export function Portfolio() {
 
   const p = data.portfolio?.value;
   const positions = data.positions?.value ?? [];
+  const optionPositions = data.optionPositions?.value ?? [];
+  const cryptoPositions = data.cryptoPositions?.value ?? [];
 
   return (
     <div className="flex flex-col gap-4 p-4">
@@ -83,55 +91,248 @@ export function Portfolio() {
       </div>
 
       <div>
-        <div className="mb-1 flex items-center justify-between">
-          <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-            Positions
-          </span>
-          {status.account && (
-            <span className="text-[11px] text-muted-foreground">
-              {status.account.agentic ? "agentic" : status.account.type} ·{" "}
-              {status.account.accountNumber}
-            </span>
-          )}
-        </div>
-        {positions.length === 0 ? (
-          <p className="py-2 text-sm text-muted-foreground">No open positions.</p>
-        ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Symbol</TableHead>
-                <TableHead className="text-right">Qty</TableHead>
-                <TableHead className="text-right">Last</TableHead>
-                <TableHead className="text-right">P&L</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {positions.map((pos) => (
-                <TableRow key={pos.symbol}>
-                  <TableCell className="font-medium">{pos.symbol}</TableCell>
-                  <TableCell className="text-right tabular-nums">{num(pos.quantity)}</TableCell>
-                  <TableCell className="text-right tabular-nums">{usd(pos.lastPrice)}</TableCell>
-                  <TableCell
-                    className={cn(
-                      "text-right tabular-nums",
-                      (pos.unrealizedPnl ?? 0) > 0 && "text-success",
-                      (pos.unrealizedPnl ?? 0) < 0 && "text-destructive",
-                    )}
-                  >
-                    {signedUsd(pos.unrealizedPnl)}
-                  </TableCell>
+        <SectionHeader
+          label="Equities"
+          open={equitiesOpen}
+          onToggle={() => setEquitiesOpen((o) => !o)}
+        />
+        {equitiesOpen &&
+          (positions.length === 0 ? (
+            <p className="py-2 text-sm text-muted-foreground">No positions.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Symbol</TableHead>
+                  <TableHead className="text-right">Qty</TableHead>
+                  <TableHead className="text-right">Last</TableHead>
+                  <MetricHead />
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        )}
+              </TableHeader>
+              <TableBody>
+                {positions.map((pos) => (
+                  <TableRow key={pos.symbol}>
+                    <TableCell className="font-medium">{pos.symbol}</TableCell>
+                    <TableCell className="text-right tabular-nums">{num(pos.quantity)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{usd(pos.lastPrice)}</TableCell>
+                    <MetricCell
+                      pnl={pos.unrealizedPnl}
+                      costBasis={pos.averageCost !== null ? pos.averageCost * pos.quantity : null}
+                      value={pos.marketValue}
+                    />
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ))}
+      </div>
+
+      {/* Option holdings, in contract units: Mark is the per-share quote, P&L is per
+          the multiplier-included cost basis. */}
+      <div>
+        <SectionHeader
+          label="Options"
+          open={optionsOpen}
+          onToggle={() => setOptionsOpen((o) => !o)}
+        />
+        {optionsOpen &&
+          (optionPositions.length === 0 ? (
+            <p className="py-2 text-sm text-muted-foreground">No positions.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Contract</TableHead>
+                  <TableHead className="text-right">Qty</TableHead>
+                  <TableHead className="text-right">Mark</TableHead>
+                  <MetricHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {optionPositions.map((pos) => (
+                  <OptionRow key={pos.optionId} pos={pos} />
+                ))}
+              </TableBody>
+            </Table>
+          ))}
+      </div>
+
+      {/* Crypto holdings: coin quantities (never "shares"), per-coin price, P&L
+          against the direct cost basis. */}
+      <div>
+        <SectionHeader label="Crypto" open={cryptoOpen} onToggle={() => setCryptoOpen((o) => !o)} />
+        {cryptoOpen &&
+          (cryptoPositions.length === 0 ? (
+            <p className="py-2 text-sm text-muted-foreground">No positions.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Asset</TableHead>
+                  <TableHead className="text-right">Qty</TableHead>
+                  <TableHead className="text-right">Price</TableHead>
+                  <MetricHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {cryptoPositions.map((pos) => (
+                  <CryptoRow key={pos.assetCode} pos={pos} />
+                ))}
+              </TableBody>
+            </Table>
+          ))}
       </div>
 
       {isStale(data.portfolio?.fetchedAt) && (
         <p className="text-[11px] text-muted-foreground">as of {ago(data.portfolio?.fetchedAt)}</p>
       )}
     </div>
+  );
+}
+
+const METRIC_LABEL: Record<PositionsMetric, string> = {
+  pnl: "P&L",
+  pct: "% Gain",
+  value: "Value",
+};
+
+/**
+ * The last column's header, shared by both tables: clicking it cycles what the
+ * column shows (P&L $ → % gain → market value), the same click-to-change family
+ * as the account value's balance masking. One store field drives both tables.
+ */
+function MetricHead() {
+  const metric = useUIStore((s) => s.positionsMetric);
+  const cycle = useUIStore((s) => s.cyclePositionsMetric);
+  return (
+    <TableHead className="text-right">
+      <button
+        type="button"
+        onClick={cycle}
+        title="Switch between P&L, % gain, and market value"
+        className="cursor-pointer underline decoration-dotted underline-offset-2 hover:text-foreground"
+      >
+        {METRIC_LABEL[metric]}
+      </button>
+    </TableHead>
+  );
+}
+
+/**
+ * The last column's cell. `costBasis` is what the position cost (per-contract
+ * basis × contracts for options — the credit received for a short, so a short's
+ * % is "fraction of the premium kept/lost"). P&L and % color by sign; Value is
+ * neutral and masks with the other balances.
+ */
+function MetricCell({
+  pnl,
+  costBasis,
+  value,
+}: {
+  pnl: number | null;
+  costBasis: number | null;
+  value: number | null;
+}) {
+  const metric = useUIStore((s) => s.positionsMetric);
+  const balancesHidden = useUIStore((s) => s.balancesHidden);
+  if (metric === "value") {
+    return (
+      <TableCell className="text-right tabular-nums">
+        {balancesHidden ? MASK : usd(value)}
+      </TableCell>
+    );
+  }
+  const pctGain =
+    metric === "pct" && pnl !== null && costBasis !== null && costBasis !== 0
+      ? pnl / Math.abs(costBasis)
+      : null;
+  // P&L dollars mask with the other balances (color still shows direction, like the
+  // account day-change line); the % metric is relative and stays visible.
+  return (
+    <TableCell
+      className={cn(
+        "text-right tabular-nums",
+        (pnl ?? 0) > 0 && "text-success",
+        (pnl ?? 0) < 0 && "text-destructive",
+      )}
+    >
+      {metric === "pnl" ? (balancesHidden ? MASK : signedUsd(pnl)) : signedPct(pctGain)}
+    </TableCell>
+  );
+}
+
+/**
+ * Collapsible section heading, in the Monitor tab's History style (13px, between the
+ * Monitor's `text-xs` and `text-sm`): the label is the toggle, the chevron rotates open.
+ */
+function SectionHeader({
+  label,
+  open,
+  onToggle,
+}: {
+  label: string;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="mb-1">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex items-center gap-1 text-[13px] font-semibold uppercase tracking-wider text-muted-foreground"
+      >
+        {label}
+        <ChevronRight className={cn("size-4 transition-transform", open && "rotate-90")} />
+      </button>
+    </div>
+  );
+}
+
+/** One crypto holding: asset code, coins (up to 8 decimals), per-coin price, metric. */
+function CryptoRow({ pos }: { pos: CryptoPosition }) {
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{pos.assetCode}</TableCell>
+      <TableCell className="text-right tabular-nums">{num(pos.quantity, 8)}</TableCell>
+      <TableCell className="text-right tabular-nums">{usd(pos.lastPrice)}</TableCell>
+      <MetricCell
+        pnl={pos.unrealizedPnl}
+        // P&L covers only the directly purchased lots (transfers have no basis),
+        // so the % denominator must be those lots' cost, not the whole holding's.
+        costBasis={
+          pos.avgCost !== null && pos.directQuantity ? pos.avgCost * pos.directQuantity : null
+        }
+        value={pos.marketValue}
+      />
+    </TableRow>
+  );
+}
+
+/** One option holding: `TLT $86C 11/20/26`, contracts (negative for a short), mark, P&L. */
+function OptionRow({ pos }: { pos: OptionPosition }) {
+  const label = contractLabel({
+    optionId: pos.optionId,
+    chainSymbol: pos.chainSymbol,
+    expirationDate: pos.expirationDate,
+    strikePrice: pos.strikePrice,
+    optionType: pos.optionType,
+    multiplier: pos.multiplier,
+  });
+  const qty = pos.type === "short" ? -pos.quantity : pos.quantity;
+  // `pendingQuantity` (contracts queued for exercise/assignment/expiry) is mapped
+  // but deliberately not surfaced yet — the row annotations (pending, partial
+  // basis, …) are being designed together; see TODO.md.
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{label}</TableCell>
+      <TableCell className="text-right tabular-nums">{num(qty)}</TableCell>
+      <TableCell className="text-right tabular-nums">{usd(pos.lastPrice)}</TableCell>
+      <MetricCell
+        pnl={pos.unrealizedPnl}
+        costBasis={pos.averagePrice !== null ? pos.averagePrice * pos.quantity : null}
+        value={pos.marketValue}
+      />
+    </TableRow>
   );
 }
 

--- a/app/src/renderer/hooks/useBroker.ts
+++ b/app/src/renderer/hooks/useBroker.ts
@@ -12,16 +12,20 @@ export function useBrokerStatus() {
   return query.data;
 }
 
-/** Portfolio + positions, invalidated whenever the poller updates the cache. */
+/** Portfolio + positions (equity and option), invalidated whenever the poller updates the cache. */
 export function useBrokerData() {
   const utils = trpc.useUtils();
   const portfolio = trpc.broker.portfolio.useQuery();
   const positions = trpc.broker.positions.useQuery();
+  const optionPositions = trpc.broker.optionPositions.useQuery();
+  const cryptoPositions = trpc.broker.cryptoPositions.useQuery();
 
   trpc.broker.onUpdated.useSubscription(undefined, {
     onData: () => {
       utils.broker.portfolio.invalidate();
       utils.broker.positions.invalidate();
+      utils.broker.optionPositions.invalidate();
+      utils.broker.cryptoPositions.invalidate();
     },
   });
 
@@ -31,7 +35,12 @@ export function useBrokerData() {
     return () => clearInterval(t);
   }, [utils]);
 
-  return { portfolio: portfolio.data, positions: positions.data };
+  return {
+    portfolio: portfolio.data,
+    positions: positions.data,
+    optionPositions: optionPositions.data,
+    cryptoPositions: cryptoPositions.data,
+  };
 }
 
 /**

--- a/app/src/renderer/lib/activity-groups.ts
+++ b/app/src/renderer/lib/activity-groups.ts
@@ -173,6 +173,16 @@ export function orderState(
   const decision = group.entries.find((e) => e.kind === "approval_decision");
   const decisionStatus = (decision?.payload as { status?: unknown } | undefined)?.status;
 
+  // An option EXERCISE is not an order: it never appears in the order ledger, so
+  // the complete-ledger "no match → failed" verdict below would wrongly go red.
+  // The broker's accept/reject of the exercise request is its terminal signal.
+  if (intentParsed(group)?.kind === "exercise") {
+    if (observedOk === true) return "filled";
+    if (observedOk === false || decisionStatus === "rejected" || decisionStatus === "expired")
+      return "failed";
+    return decisionStatus === "approved" ? "working" : "proposed";
+  }
+
   if (observedOk === false || decisionStatus === "rejected" || decisionStatus === "expired")
     return "failed";
   if (orderId) return "working"; // reached RH, just not in the cached ledger (yet)

--- a/app/src/renderer/lib/format.ts
+++ b/app/src/renderer/lib/format.ts
@@ -14,6 +14,13 @@ export function signedUsd(value: number | null | undefined): string {
   return value < 0 ? `-${s}` : `+${s}`;
 }
 
+/** Format a fraction (0.031) as a signed percent ("+3.10%" / "-3.10%"). */
+export function signedPct(fraction: number | null | undefined): string {
+  if (fraction === null || fraction === undefined) return "—";
+  const s = `${(Math.abs(fraction) * 100).toFixed(2)}%`;
+  return fraction < 0 ? `-${s}` : `+${s}`;
+}
+
 /** Format a fraction (0.0072) as an unsigned percent ("0.72%"). */
 export function pct(fraction: number | null | undefined): string {
   if (fraction === null || fraction === undefined) return "—";

--- a/app/src/renderer/stores/ui.ts
+++ b/app/src/renderer/stores/ui.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 
 export type RightTab = "portfolio" | "activity" | "monitor";
+/** What the Portfolio tables' last column shows. Cycled by clicking the column header. */
+export type PositionsMetric = "pnl" | "pct" | "value";
 /** Top-level pane: the agent workspace, the full-screen Scheduled view, or Settings. */
 export type AppView = "agents" | "scheduled" | "settings";
 
@@ -12,13 +14,22 @@ interface UIState {
   newAgentOpen: boolean;
   /** Hide dollar balances in the Portfolio pane (masked as ****). Session-only. */
   balancesHidden: boolean;
+  /** Last column of the Equities/Options tables: P&L $ / % gain / market value. Session-only. */
+  positionsMetric: PositionsMetric;
   select: (id: string | null) => void;
   setRightTab: (tab: RightTab) => void;
   setView: (view: AppView) => void;
   openNewAgent: () => void;
   closeNewAgent: () => void;
   toggleBalances: () => void;
+  cyclePositionsMetric: () => void;
 }
+
+const METRIC_CYCLE: Record<PositionsMetric, PositionsMetric> = {
+  pnl: "pct",
+  pct: "value",
+  value: "pnl",
+};
 
 export const useUIStore = create<UIState>((set) => ({
   selectedAgentId: null,
@@ -26,10 +37,12 @@ export const useUIStore = create<UIState>((set) => ({
   view: "agents",
   newAgentOpen: false,
   balancesHidden: false,
+  positionsMetric: "pnl",
   select: (id) => set({ selectedAgentId: id }),
   setRightTab: (tab) => set({ rightTab: tab }),
   setView: (view) => set({ view }),
   openNewAgent: () => set({ newAgentOpen: true }),
   closeNewAgent: () => set({ newAgentOpen: false }),
   toggleBalances: () => set((s) => ({ balancesHidden: !s.balancesHidden })),
+  cyclePositionsMetric: () => set((s) => ({ positionsMetric: METRIC_CYCLE[s.positionsMetric] })),
 }));

--- a/app/src/shared/analytics.ts
+++ b/app/src/shared/analytics.ts
@@ -53,10 +53,10 @@ const stackFrame = z
   .regex(/^(?:(?:@[\w.-]+\/)?[\w.-]+\/)?[\w.-]+\.js:\d+(?::\d+)?$/);
 const frames = z.array(stackFrame).max(10);
 
-const assetType = z.enum(["equity", "option", "other"]);
+const assetType = z.enum(["equity", "option", "crypto", "other"]);
 const orderSide = z.enum(["buy", "sell", "other"]);
 const orderType = z.enum(["market", "limit", "other"]);
-const orderKind = z.enum(["place", "cancel"]);
+const orderKind = z.enum(["place", "cancel", "exercise"]);
 
 /** Subsystem an `app_error` originated in. */
 export const ErrorSubsystem = z.enum([
@@ -258,10 +258,12 @@ export type RendererTrackInput = z.infer<typeof RendererTrackInput>;
 
 // ---- categorical normalizers (call sites pass raw values through these) ----
 
-/** equity vs option, from the Robinhood order tool name. */
+/** equity/option/crypto, from the Robinhood order tool name. `_option` deliberately
+ *  has no trailing underscore so `exercise_option`/`cancel_option_exercise` count too. */
 export function assetTypeOf(toolName: string): z.infer<typeof assetType> {
   if (/_equity_/.test(toolName)) return "equity";
-  if (/_option_/.test(toolName)) return "option";
+  if (/_option/.test(toolName)) return "option";
+  if (/_crypto_/.test(toolName)) return "crypto";
   return "other";
 }
 
@@ -277,9 +279,11 @@ export function orderTypeOf(type: string | null | undefined): z.infer<typeof ord
   return t === "market" || t === "limit" ? t : "other";
 }
 
-/** place vs cancel from a parsed order kind. */
+/** place / cancel / exercise from a parsed order kind (anything else counts as place). */
 export function orderKindOf(kind: string | null | undefined): z.infer<typeof orderKind> {
-  return kind === "cancel" ? "cancel" : "place";
+  if (kind === "cancel") return "cancel";
+  if (kind === "exercise") return "exercise";
+  return "place";
 }
 
 /** Normalize a template id to the allowlist (unknown → "other"). */

--- a/app/src/shared/approval.ts
+++ b/app/src/shared/approval.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { OptionLeg } from "./options";
 
 /**
  * Best-effort structured view of an order tool's input, parsed from the exact
@@ -6,7 +7,8 @@ import { z } from "zod";
  * row; this is only for the human-facing card and is allowed to be incomplete.
  */
 export const ParsedOrder = z.object({
-  kind: z.enum(["place", "cancel", "unknown"]),
+  /** `exercise` = `exercise_option` (its cancel parses as `cancel`); additive for old rows. */
+  kind: z.enum(["place", "cancel", "exercise", "unknown"]),
   symbol: z.string().nullable(),
   side: z.string().nullable(),
   quantity: z.number().nullable(),
@@ -21,6 +23,20 @@ export const ParsedOrder = z.object({
   cancelsOrderId: z.string().nullable().optional(),
   /** Human-readable one-liner, e.g. "BUY 10 AAPL @ market — est. $2,150". */
   summary: z.string(),
+  // ---- asset-specific (absent on equity rows and on rows written before these were modelled) ----
+  assetType: z.enum(["equity", "option", "crypto"]).optional(),
+  /**
+   * What is being traded, for display where an equity would show its symbol: the
+   * contract (`TLT $86C 11/20/26`) or, for a spread, the underlying + leg count.
+   * For an option `symbol` is the underlying.
+   */
+  instrument: z.string().nullable().optional(),
+  legs: z.array(OptionLeg).optional(),
+  /** Shares per contract; `estCost` already includes it. */
+  multiplier: z.number().nullable().optional(),
+  /** Net "debit" | "credit" (multi-leg). */
+  direction: z.string().nullable().optional(),
+  stopPrice: z.number().nullable().optional(),
 });
 export type ParsedOrder = z.infer<typeof ParsedOrder>;
 

--- a/app/src/shared/broker.ts
+++ b/app/src/shared/broker.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
+import { OptionContract, OptionLeg } from "./options";
 
 export const Account = z.object({
   accountNumber: z.string(),
+  /** Numeric brokerage id (`rhs_account_number`) — the key CRYPTO tools take. */
+  rhsAccountNumber: z.string().nullable().optional(),
   type: z.string(),
   agentic: z.boolean(),
   isDefault: z.boolean(),
@@ -18,6 +21,11 @@ export const Portfolio = z.object({
   dayChange: z.number().nullable(),
   /** Today's move as a fraction of the prior account value (e.g. 0.0072 = +0.72%). */
   dayChangePct: z.number().nullable(),
+  /** Market value of option holdings (RH `options_value`); part of `equity`. Absent on
+   *  rows cached before options were modelled. */
+  optionsValue: z.number().nullable().optional(),
+  /** Market value of crypto holdings (RH `crypto_value`); part of `equity`. */
+  cryptoValue: z.number().nullable().optional(),
 });
 export type Portfolio = z.infer<typeof Portfolio>;
 
@@ -34,18 +42,89 @@ export const Position = z.object({
 export type Position = z.infer<typeof Position>;
 
 /**
+ * An open option position (`get_option_positions`). Prices follow Robinhood's own
+ * units: `averagePrice` is the **per-contract** cost basis *including* the
+ * multiplier (a $0.79 contract shows `79`), while `lastPrice`/`previousClose` are
+ * **per-share** quotes (`mark_price`, `0.79`) — so market value is
+ * `last × multiplier × quantity`. `type` is long/short; a short's P&L is inverted.
+ */
+export const OptionPosition = z.object({
+  optionId: z.string(),
+  chainId: z.string().nullable(),
+  chainSymbol: z.string(),
+  type: z.string().nullable(),
+  quantity: z.number(),
+  /** Contracts opened today (drives the intraday-aware day-change split). */
+  intradayQuantity: z.number().nullable(),
+  /** Per-contract cost basis, multiplier included (RH `average_price`). */
+  averagePrice: z.number().nullable(),
+  /** Per-contract basis of the contracts opened today, multiplier included. */
+  intradayAverageOpenPrice: z.number().nullable(),
+  expirationDate: z.string().nullable(),
+  multiplier: z.number().nullable(),
+  /** From the resolved contract; null until `get_option_instruments` has been consulted. */
+  strikePrice: z.number().nullable(),
+  optionType: z.enum(["call", "put"]).nullable(),
+  /** Per-share mark (`mark_price`); null until a quote is folded in. */
+  lastPrice: z.number().nullable(),
+  /** Per-share prior-session close. */
+  previousClose: z.number().nullable(),
+  marketValue: z.number().nullable(),
+  unrealizedPnl: z.number().nullable(),
+  /** Contracts queued for exercise/assignment/expiry — RH asks these be surfaced. */
+  pendingQuantity: z.number().nullable(),
+});
+export type OptionPosition = z.infer<typeof OptionPosition>;
+
+/**
+ * An open crypto holding (`get_crypto_positions`). Quantities are in coins (never
+ * "shares"); prices are folded in from `get_crypto_quotes` at poll time. `avgCost`
+ * is per coin, from the summed direct cost bases — transfers/rewards carry no
+ * basis, so when `directQuantity < quantity` the average covers only a subset.
+ */
+export const CryptoPosition = z.object({
+  /** Asset code, e.g. "BTC" (RH `currency.code`). */
+  assetCode: z.string(),
+  quantity: z.number(),
+  /** Sellable right now (nets out open sells/holds); RH `quantity_transferable`. */
+  transferableQuantity: z.number().nullable(),
+  /** Per-coin average cost over direct purchases; null when no basis is captured. */
+  avgCost: z.number().nullable(),
+  /** Coins with a captured direct cost basis (≤ quantity). */
+  directQuantity: z.number().nullable(),
+  /** Coins acquired today (best-effort; drives the intraday day-change split). */
+  intradayQuantity: z.number().nullable(),
+  /** Per-coin mark, folded from the quote. */
+  lastPrice: z.number().nullable(),
+  /** Prior-day close (midnight-ET boundary, RH `open_price`). */
+  previousClose: z.number().nullable(),
+  marketValue: z.number().nullable(),
+  unrealizedPnl: z.number().nullable(),
+});
+export type CryptoPosition = z.infer<typeof CryptoPosition>;
+
+/**
  * The broker's authoritative view of an order's execution, read from
- * `get_equity_orders` (the agentic ledger). This is the source of truth for the
- * Activity dot — never inferred from our own events. `state` is RH's own status
- * (`filled` / `partially_filled` / `queued` / `cancelled` / `rejected` / …).
+ * `get_equity_orders` / `get_option_orders` (the agentic ledger). This is the source
+ * of truth for the Activity dot — never inferred from our own events. `state` is
+ * RH's own status (`filled` / `partially_filled` / `queued` / `cancelled` /
+ * `rejected` / …).
  *
  * Fill fields are exact: `avgPrice` is the VWAP (`average_price`) and
  * `cumulativeQuantity` the executed shares (`cumulative_quantity`) — distinct
  * from the *ordered* `quantity` and the limit `limitPrice` (`price`, null for
  * market orders), which is what the old mapper wrongly used.
+ *
+ * Option orders reuse the same shape in **per-contract, per-share** units — `quantity`
+ * is contracts, `avgPrice`/`limitPrice` are per share (`$0.79`) — plus the fields
+ * under "options": `multiplier` (100) turns a price into dollars, `legs` names the
+ * contracts, `symbol` is the underlying (`chain_symbol`), `side` is the single leg's
+ * side or, for a spread, the net `direction` (debit/credit). `assetType` is absent
+ * on ledger rows cached before options were modelled — read absent as equity.
  */
 export const OrderStatus = z.object({
   id: z.string(),
+  assetType: z.enum(["equity", "option", "crypto"]).optional(),
   symbol: z.string().nullable(),
   side: z.string().nullable(),
   /** "market" | "limit" | … (RH `type`). */
@@ -65,6 +144,17 @@ export const OrderStatus = z.object({
   dollarAmount: z.number().nullable(),
   createdAt: z.string().nullable(),
   lastTransactionAt: z.string().nullable(),
+  // ---- options ----
+  /** Shares per contract; null/absent for equities. */
+  multiplier: z.number().nullable().optional(),
+  /** Net "debit" | "credit" for the whole order. */
+  direction: z.string().nullable().optional(),
+  /** RH's `opening_strategy` / `closing_strategy` (`long_call`, `call_debit_spread`, …). */
+  strategy: z.string().nullable().optional(),
+  legs: z.array(OptionLeg).optional(),
+  /** Net premium ordered (`premium`, dollars) and executed (`processed_premium`). */
+  premium: z.number().nullable().optional(),
+  processedPremium: z.number().nullable().optional(),
 });
 export type OrderStatus = z.infer<typeof OrderStatus>;
 
@@ -76,6 +166,34 @@ export const Quote = z.object({
   bidPrice: z.number().nullable(),
 });
 export type Quote = z.infer<typeof Quote>;
+
+/** A live option-contract quote (`get_option_quotes`), per share. */
+export const OptionQuote = z.object({
+  optionId: z.string(),
+  mark: z.number().nullable(),
+  bidPrice: z.number().nullable(),
+  askPrice: z.number().nullable(),
+  /** The official prior-session close (`results[].close.price`), else RH's `previous_close_price`. */
+  previousClose: z.number().nullable(),
+  impliedVolatility: z.number().nullable(),
+  delta: z.number().nullable(),
+  theta: z.number().nullable(),
+});
+export type OptionQuote = z.infer<typeof OptionQuote>;
+
+/** A live crypto pair quote (`get_crypto_quotes`), per coin. */
+export const CryptoQuote = z.object({
+  /** Unhyphenated pair symbol as RH returns it ("BTCUSD"); assetCode is the prefix. */
+  symbol: z.string(),
+  mark: z.number().nullable(),
+  bidPrice: z.number().nullable(),
+  askPrice: z.number().nullable(),
+  /** RH `open_price` — the prior-day close at the midnight-ET boundary. */
+  previousClose: z.number().nullable(),
+});
+export type CryptoQuote = z.infer<typeof CryptoQuote>;
+
+export { OptionContract, OptionLeg };
 
 export const BrokerConnectionStatus = z.enum(["disconnected", "connecting", "connected", "error"]);
 export type BrokerConnectionStatus = z.infer<typeof BrokerConnectionStatus>;

--- a/app/src/shared/options.test.ts
+++ b/app/src/shared/options.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import {
+  contractLabel,
+  legActionLabel,
+  legsLabel,
+  type OptionContract,
+  shortExpiry,
+  strategyLabel,
+} from "./options";
+
+const tlt: OptionContract = {
+  optionId: "e9c444cc-5ccc-4dfe-8fd9-64daf22d6338",
+  chainSymbol: "TLT",
+  expirationDate: "2026-11-20",
+  strikePrice: 86,
+  optionType: "call",
+  multiplier: 100,
+};
+
+describe("contractLabel", () => {
+  test("full contract reads symbol $strikeC/P M/D/YY", () => {
+    expect(contractLabel(tlt)).toBe("TLT $86C 11/20/26");
+    expect(contractLabel({ ...tlt, optionType: "put", strikePrice: 86.5 })).toBe(
+      "TLT $86.5P 11/20/26",
+    );
+  });
+  test("degrades field by field, never to an empty string", () => {
+    expect(contractLabel({ ...tlt, strikePrice: null, optionType: null })).toBe("TLT 11/20/26");
+    expect(
+      contractLabel({ ...tlt, strikePrice: null, optionType: null, expirationDate: null }),
+    ).toBe("TLT option");
+    expect(
+      contractLabel({
+        ...tlt,
+        chainSymbol: null,
+        strikePrice: null,
+        optionType: null,
+        expirationDate: null,
+      }),
+    ).toBe("option");
+    expect(contractLabel(null)).toBe("option");
+  });
+});
+
+test("shortExpiry", () => {
+  expect(shortExpiry("2026-11-20")).toBe("11/20/26");
+  expect(shortExpiry("2027-01-05")).toBe("1/5/27");
+  expect(shortExpiry("weird")).toBe("weird");
+  expect(shortExpiry(null)).toBeNull();
+});
+
+describe("legsLabel", () => {
+  const leg = (c: OptionContract | null) => ({
+    optionId: c?.optionId ?? "x",
+    side: "buy",
+    positionEffect: "open",
+    ratioQuantity: 1,
+    contract: c,
+  });
+  test("single leg is its contract", () => {
+    expect(legsLabel([leg(tlt)])).toBe("TLT $86C 11/20/26");
+    expect(legsLabel([leg(null)])).toBe("option");
+  });
+  test("multi-leg names the underlying and leg count", () => {
+    expect(legsLabel([leg(tlt), leg({ ...tlt, strikePrice: 90 })])).toBe("TLT 2-leg spread");
+    expect(legsLabel([leg(null), leg(null)])).toBe("2-leg spread");
+  });
+  test("no legs", () => {
+    expect(legsLabel([])).toBe("option");
+  });
+});
+
+test("strategyLabel / legActionLabel humanize RH's snake_case", () => {
+  expect(strategyLabel("long_call")).toBe("Long call");
+  expect(strategyLabel("call_debit_spread")).toBe("Call debit spread");
+  expect(strategyLabel(null)).toBeNull();
+  expect(legActionLabel("buy", "open")).toBe("Buy to open");
+  expect(legActionLabel("sell", "close")).toBe("Sell to close");
+  expect(legActionLabel("sell", null)).toBe("Sell");
+  expect(legActionLabel(null, null)).toBe("Order");
+});

--- a/app/src/shared/options.ts
+++ b/app/src/shared/options.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+/**
+ * An option contract as Robinhood identifies it. Everywhere an option *order* is
+ * expressed (tool input, ledger, positions) the contract is referenced by its
+ * `option_id` UUID alone — the human-readable identity (underlying, expiry, strike,
+ * call/put) comes from `get_option_instruments` (or, for ledger orders, the legs of
+ * the order response). Fields are nullable so a partially-resolved contract still
+ * renders something rather than nothing.
+ */
+export const OptionContract = z.object({
+  optionId: z.string(),
+  chainSymbol: z.string().nullable(),
+  /** YYYY-MM-DD. */
+  expirationDate: z.string().nullable(),
+  strikePrice: z.number().nullable(),
+  optionType: z.enum(["call", "put"]).nullable(),
+  /** Shares per contract (`trade_value_multiplier`); 100 for a standard contract. */
+  multiplier: z.number().nullable(),
+});
+export type OptionContract = z.infer<typeof OptionContract>;
+
+/** One leg of an option order, as the agent submitted it (plus the resolved contract). */
+export const OptionLeg = z.object({
+  optionId: z.string(),
+  side: z.string().nullable(),
+  /** "open" | "close". */
+  positionEffect: z.string().nullable(),
+  ratioQuantity: z.number().nullable(),
+  contract: OptionContract.nullable(),
+});
+export type OptionLeg = z.infer<typeof OptionLeg>;
+
+export const STANDARD_MULTIPLIER = 100;
+
+/** "86", "86.5", "1,250" — a strike with the trailing zeros RH pads it with dropped. */
+function strike(n: number): string {
+  return n.toLocaleString("en-US", { maximumFractionDigits: 4 });
+}
+
+/** "2026-11-20" → "11/20/26". Anything unparsable passes through verbatim. */
+export function shortExpiry(iso: string | null): string | null {
+  if (!iso) return null;
+  const m = iso.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return iso;
+  return `${Number(m[2])}/${Number(m[3])}/${m[1].slice(2)}`;
+}
+
+/**
+ * The compact contract line used everywhere a symbol would go for an equity:
+ * `TLT $86C 11/20/26`. Degrades field by field — a contract we only know the
+ * underlying of reads `TLT option`; one we know nothing about reads `option`.
+ */
+export function contractLabel(c: OptionContract | null | undefined): string {
+  if (!c) return "option";
+  const sym = c.chainSymbol ?? "";
+  const cp = c.optionType === "call" ? "C" : c.optionType === "put" ? "P" : "";
+  const strikePart = c.strikePrice != null ? `$${strike(c.strikePrice)}${cp}` : cp;
+  const exp = shortExpiry(c.expirationDate) ?? "";
+  const parts = [sym, strikePart, exp].filter(Boolean);
+  if (parts.length === 0) return "option";
+  if (parts.length === 1 && sym) return `${sym} option`;
+  return parts.join(" ");
+}
+
+/**
+ * The instrument line for a whole order. A single leg is its contract; a multi-leg
+ * strategy names the underlying and the leg count (`TLT 2-leg spread`) — the legs
+ * themselves are listed separately where there's room.
+ */
+export function legsLabel(legs: OptionLeg[]): string {
+  if (legs.length === 0) return "option";
+  if (legs.length === 1) return contractLabel(legs[0].contract);
+  const sym = legs.find((l) => l.contract?.chainSymbol)?.contract?.chainSymbol;
+  return `${sym ? `${sym} ` : ""}${legs.length}-leg spread`;
+}
+
+/** "long_call" → "Long call"; null/empty → null. RH's strategy names are snake_case. */
+export function strategyLabel(s: string | null | undefined): string | null {
+  if (!s) return null;
+  const words = s.replace(/_/g, " ").trim();
+  return words ? words[0].toUpperCase() + words.slice(1) : null;
+}
+
+/** "buy" + "open" → "Buy to open"; a missing effect gives just the side. */
+export function legActionLabel(side: string | null, positionEffect: string | null): string {
+  const s = side ? side[0].toUpperCase() + side.slice(1).toLowerCase() : "Order";
+  return positionEffect ? `${s} to ${positionEffect.toLowerCase()}` : s;
+}

--- a/app/src/shared/robinhood-tools.test.ts
+++ b/app/src/shared/robinhood-tools.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  COSMETIC_WRITES,
+  GATED_TOOL_MATCHER,
+  GATED_TOOLS,
+  MONEY_MOVERS,
+  PREALLOWED_TOOL_PATTERNS,
+  READ_PATTERNS,
+} from "./robinhood-tools";
+
+const asRegex = new RegExp(`^${GATED_TOOL_MATCHER}$`);
+
+describe("the gate table", () => {
+  test("every money-mover on today's server is present, by name", () => {
+    // Pinned literally so gutting the table breaks this test, not just the derived
+    // artifacts. Update alongside LAST_VERIFIED when Robinhood ships new ones.
+    expect([...MONEY_MOVERS].sort()).toEqual(
+      [
+        "place_equity_order",
+        "cancel_equity_order",
+        "place_option_order",
+        "cancel_option_order",
+        "place_crypto_order",
+        "cancel_crypto_order",
+        "exercise_option",
+        "cancel_option_exercise",
+      ].sort(),
+    );
+    expect(GATED_TOOLS).toEqual(MONEY_MOVERS);
+  });
+
+  test("the derived matcher gates every money-mover and nothing else", () => {
+    for (const t of MONEY_MOVERS) {
+      expect(asRegex.test(`mcp__robinhood__${t}`)).toBe(true);
+    }
+    for (const name of [
+      "get_equity_quotes",
+      "get_option_positions",
+      "get_crypto_orders",
+      "search",
+      "run_scan",
+      "review_option_order",
+      "preview_crypto_order",
+      ...COSMETIC_WRITES,
+    ]) {
+      expect(asRegex.test(`mcp__robinhood__${name}`)).toBe(false);
+    }
+    // Unknown future tools are deliberately NOT gated (policy: money-movers only).
+    expect(asRegex.test("mcp__robinhood__place_futures_order")).toBe(false);
+  });
+
+  test("no tool is both gated and pre-allowed", () => {
+    for (const t of MONEY_MOVERS) {
+      expect(PREALLOWED_TOOL_PATTERNS).not.toContain(`mcp__robinhood__${t}`);
+      // No wildcard may swallow a money-mover either (prefix check against `*` rules).
+      for (const p of READ_PATTERNS) {
+        if (!p.endsWith("*")) continue;
+        expect(t.startsWith(p.slice(0, -1))).toBe(false);
+      }
+    }
+  });
+
+  test("simulations and cosmetic writes are pre-allowed", () => {
+    expect(PREALLOWED_TOOL_PATTERNS).toContain("mcp__robinhood__review_*");
+    expect(PREALLOWED_TOOL_PATTERNS).toContain("mcp__robinhood__preview_*");
+    for (const t of COSMETIC_WRITES) {
+      expect(PREALLOWED_TOOL_PATTERNS).toContain(`mcp__robinhood__${t}`);
+    }
+  });
+});

--- a/app/src/shared/robinhood-tools.ts
+++ b/app/src/shared/robinhood-tools.ts
@@ -1,0 +1,81 @@
+/**
+ * The single source of truth for how Robinhood MCP tools are gated. Both harness
+ * configs derive from this table — claude's `.claude/settings.json` (PreToolUse/
+ * PostToolUse matcher + permissions allowlist, `harness/claude.ts`) and codex's
+ * `config.toml` per-tool approval modes + `hooks.json` matcher (`harness/codex.ts`).
+ * Before this module the same list was hand-copied in three places and rotted:
+ * Robinhood shipped `place_option_order` and later `place_crypto_order`, and orders
+ * ran ungated until someone noticed.
+ *
+ * LAST_VERIFIED is when a human last diffed this table against the live server's
+ * tool list (connect an MCP client to https://agent.robinhood.com/mcp/trading and
+ * list tools). When Robinhood ships new tools, classify each one here:
+ *  - moves money (place/cancel/exercise anything) → MONEY_MOVERS (gated);
+ *  - writes state but can't move money (watchlists, scans) → COSMETIC_WRITES
+ *    (pre-allowed);
+ *  - read-only or a pure simulation → covered by READ_PATTERNS, or add the name.
+ * Policy (Pranav, 2026-08-31): gate money-movers only; tools this table doesn't
+ * know are NOT gated — which is exactly why it must be kept current.
+ */
+export const LAST_VERIFIED = "2026-08-31";
+
+/**
+ * Tools that move real money (or irreversibly commit it — an exercise past
+ * `queued` cannot be recalled). Every name here is gated behind the human
+ * approval card in both harnesses.
+ */
+export const MONEY_MOVERS = [
+  "place_equity_order",
+  "cancel_equity_order",
+  "place_option_order",
+  "cancel_option_order",
+  "place_crypto_order",
+  "cancel_crypto_order",
+  "exercise_option",
+  "cancel_option_exercise",
+] as const;
+
+/**
+ * Writes that cannot move money — watchlist and scanner bookkeeping. Pre-allowed
+ * so agents don't raise Claude Code's generic permission prompt for cosmetics
+ * (codex pre-approves them via the server-level default already).
+ */
+export const COSMETIC_WRITES = [
+  "add_to_watchlist",
+  "remove_from_watchlist",
+  "add_option_to_watchlist",
+  "remove_option_from_watchlist",
+  "create_watchlist",
+  "update_watchlist",
+  "follow_watchlist",
+  "unfollow_watchlist",
+  "create_scan",
+  "update_scan_config",
+  "update_scan_filters",
+] as const;
+
+/**
+ * Read-only tool name patterns (Claude Code permission-rule wildcards, not
+ * regexes): every `get_*`, the resolvers/screeners, and the order *simulations*
+ * (`review_*` / `preview_*` price an order without placing it).
+ */
+export const READ_PATTERNS = ["get_*", "search", "run_scan", "review_*", "preview_*"] as const;
+
+/** MCP prefix Claude Code exposes the server's tools under (server name "robinhood"). */
+const PREFIX = "mcp__robinhood__";
+
+/**
+ * The gate matcher for both harnesses' hooks configs: an alternation of the
+ * exact money-mover names — deliberately no open-ended wildcard, so an unknown
+ * future tool is NOT gated (see the policy note above).
+ */
+export const GATED_TOOL_MATCHER = `${PREFIX}(${MONEY_MOVERS.join("|")})`;
+
+/** Bare gated names, for codex's per-tool `[mcp_servers.robinhood.tools.<t>]` TOML. */
+export const GATED_TOOLS: readonly string[] = MONEY_MOVERS;
+
+/** Claude `permissions.allow` entries for everything that is not a money-mover. */
+export const PREALLOWED_TOOL_PATTERNS: readonly string[] = [
+  ...READ_PATTERNS.map((p) => `${PREFIX}${p}`),
+  ...COSMETIC_WRITES.map((t) => `${PREFIX}${t}`),
+];

--- a/templates/agents/AGENTS.prefix.codex.md
+++ b/templates/agents/AGENTS.prefix.codex.md
@@ -1,6 +1,6 @@
 # OpenTrade Agent
 
-You are a **trading agent** running inside **OpenTrade**, an open-source macOS app. You are a persistent Codex (OpenAI) session living in your own folder, embedded in OpenTrade's terminal, connected to Robinhood's Agentic Trading MCP. You trade **equities only** (beta) in the user's **dedicated, funded Robinhood agentic sub-account**.
+You are a **trading agent** running inside **OpenTrade**, an open-source macOS app. You are a persistent Codex (OpenAI) session living in your own folder, embedded in OpenTrade's terminal, connected to Robinhood's Agentic Trading MCP. You trade **equities, options, and crypto** in the user's **dedicated, funded Robinhood agentic sub-account**.
 
 Your job is to help one user run a trading strategy *they* design with you: research, watch markets, propose and place orders, and keep an honest journal of your reasoning. **Your specialty — and the discipline it demands — is described at the end of this document; read it as your operating mandate.**
 
@@ -25,6 +25,8 @@ Use the Robinhood MCP directly for all market data lookups in your agent session
 - **`get_equity_quotes`** — current bid/ask/last for one or more symbols
 - **`get_equity_positions`** — your open positions and unrealized P&L
 - **`get_equity_historicals`** — OHLCV history for trend analysis
+- **Options:** `get_option_chains` (expirations for an underlying) → `get_option_instruments` (contracts by expiry/strike/type; gives the `option_id` an order needs) → `get_option_quotes` (mark, bid/ask, Greeks by `option_id`); `get_option_positions` for open contracts, `get_option_orders` for order history.
+- **Crypto:** `get_crypto_quotes` (bid/ask/mark by pair, e.g. `BTC-USD`), `get_crypto_positions` (holdings; keyed by the account's `rhs_account_number` from `get_accounts`), `get_crypto_orders`, `get_currency_pairs` (tradable pairs).
 
 **The OpenTrade local server is for scheduling only** — never use it as a data source in your reasoning or decision-making. Robinhood MCP is your only source of truth for prices and positions.
 
@@ -33,8 +35,10 @@ Use the Robinhood MCP directly for all market data lookups in your agent session
 ### Trade execution — Robinhood MCP
 The MCP server is named `robinhood`.
 - Read-only tools (`get_*`) are pre-allowed.
-- Order-placing tools go through the approval gate when approval mode is on.
-- Equities only for now. Don't attempt asset classes the MCP doesn't support.
+- Order-placing tools go through the approval gate when approval mode is on — equity, option, and crypto places/cancels, and option exercises alike.
+- Option prices are quoted **per share**: a contract at $0.79 costs $79 (× `trade_value_multiplier`, normally 100). Size positions and write your journal in dollars, not quote points. What you may trade, and at what options level, is between the user and Robinhood — follow the tools' own guidance.
+- Crypto quantities are **coins, never "shares"** — write `0.0015 BTC`, and mind the wide spread on market orders (`preview_crypto_order` shows the estimated cost first, like the review tools do for equities and options).
+- Equities, options, and crypto only — don't attempt asset classes the MCP doesn't support.
 
 ## Self-scheduling — staying awake on the user's behalf
 OpenTrade gives you **durable** scheduling through its own MCP server (`opentrade`), backed by an always-on host. **The `opentrade` MCP server is for scheduling only** — `CronCreate`, `Monitor`, and their list/delete counterparts; all price data comes from Robinhood MCP. Use it for anything that must keep working when the desktop app is closed:

--- a/templates/agents/CLAUDE.prefix.md
+++ b/templates/agents/CLAUDE.prefix.md
@@ -1,6 +1,6 @@
 # OpenTrade Agent
 
-You are a **trading agent** running inside **OpenTrade**, an open-source macOS app. You are a persistent Claude Code session living in your own folder, embedded in OpenTrade's terminal, connected to Robinhood's Agentic Trading MCP. You trade **equities only** (beta) in the user's **dedicated, funded Robinhood agentic sub-account**.
+You are a **trading agent** running inside **OpenTrade**, an open-source macOS app. You are a persistent Claude Code session living in your own folder, embedded in OpenTrade's terminal, connected to Robinhood's Agentic Trading MCP. You trade **equities, options, and crypto** in the user's **dedicated, funded Robinhood agentic sub-account**.
 
 Your job is to help one user run a trading strategy *they* design with you: research, watch markets, propose and place orders, and keep an honest journal of your reasoning. **Your specialty — and the discipline it demands — is described at the end of this document; read it as your operating mandate.**
 
@@ -25,6 +25,8 @@ Use the Robinhood MCP directly for all market data lookups in your agent session
 - **`mcp__robinhood__get_equity_quotes`** — current bid/ask/last for one or more symbols
 - **`mcp__robinhood__get_equity_positions`** — your open positions and unrealized P&L
 - **`mcp__robinhood__get_equity_historicals`** — OHLCV history for trend analysis
+- **Options:** `mcp__robinhood__get_option_chains` (expirations for an underlying) → `mcp__robinhood__get_option_instruments` (contracts by expiry/strike/type; gives the `option_id` an order needs) → `mcp__robinhood__get_option_quotes` (mark, bid/ask, Greeks by `option_id`); `mcp__robinhood__get_option_positions` for open contracts, `mcp__robinhood__get_option_orders` for order history.
+- **Crypto:** `mcp__robinhood__get_crypto_quotes` (bid/ask/mark by pair, e.g. `BTC-USD`), `mcp__robinhood__get_crypto_positions` (holdings; keyed by the account's `rhs_account_number` from `mcp__robinhood__get_accounts`), `mcp__robinhood__get_crypto_orders`, `mcp__robinhood__get_currency_pairs` (tradable pairs).
 
 **The OpenTrade local server is for scheduling only** — never use it as a data source in your reasoning or decision-making. Robinhood MCP is your only source of truth for prices and positions.
 
@@ -33,8 +35,10 @@ Use the Robinhood MCP directly for all market data lookups in your agent session
 ### Trade execution — Robinhood MCP
 The MCP server is named `robinhood` (see `.mcp.json`); its tools appear as `mcp__robinhood__*`.
 - Read-only tools (`mcp__robinhood__get_*`) are pre-allowed.
-- Order-placing tools go through the approval gate when approval mode is on.
-- Equities only for now. Don't attempt asset classes the MCP doesn't support.
+- Order-placing tools go through the approval gate when approval mode is on — equity, option, and crypto places/cancels, and option exercises alike.
+- Option prices are quoted **per share**: a contract at $0.79 costs $79 (× `trade_value_multiplier`, normally 100). Size positions and write your journal in dollars, not quote points. What you may trade, and at what options level, is between the user and Robinhood — follow the tools' own guidance.
+- Crypto quantities are **coins, never "shares"** — write `0.0015 BTC`, and mind the wide spread on market orders (`preview_crypto_order` shows the estimated cost first, like the review tools do for equities and options).
+- Equities, options, and crypto only — don't attempt asset classes the MCP doesn't support.
 
 ## Self-scheduling — staying awake on the user's behalf
 OpenTrade gives you **durable** scheduling through its own MCP server (`opentrade`), backed by an always-on host. **The `opentrade` MCP server is for scheduling only** — `CronCreate`, `Monitor`, and their list/delete counterparts; all price data comes from Robinhood MCP. Use it for anything that must keep working when the desktop app is closed:


### PR DESCRIPTION
Robinhood's Agentic Trading MCP now exposes option and crypto trading alongside equities. This PR teaches the whole pipeline about all three asset classes and centralizes which tools require human approval.

## Order gate
- **`shared/robinhood-tools.ts`** is the single classification table (with a `LAST_VERIFIED` date) for every tool on the Robinhood server: **money movers** — equity/option/crypto places + cancels, `exercise_option`, `cancel_option_exercise` — are gated behind the approval card; watchlist/scan writes, reads, and order simulations are pre-allowed.
- Both harness configs **derive** their hook matcher, per-tool approval entries, and allowlist from the table. Previously the gated list was hand-copied into three places (plus an unused fourth) and missed newly shipped tools, letting real orders run ungated.

## Options
- Gate cards resolve `option_id`s to contracts (bounded, cache-first): `BUY 1 TLT $86C 11/20/26 to open @ $0.79 limit — est. $79.00`, with est. cost including the contract multiplier.
- `get_option_orders` joins the order ledger (fills reach terminal states and notify); `get_option_positions` polls with contract identity + quote marks folded in.
- Exercises get priced cards (strike × multiplier × qty, `allow_shorts` surfaced) and their own Activity state — exercises never appear in the order ledger.

## Crypto
- Flat order input parses with coin units, pair-symbol normalization, and `stop_loss` rendered as a stop-triggered market order; `get_crypto_orders`/`get_crypto_positions` join the ledger and Portfolio; keyed by `rhs_account_number`. Coin quantities are never called "shares".

## UI
- Portfolio: three always-present collapsible sections (Equities / Options / Crypto, "No positions." when empty); last column cycles **P&L / % gain / value** via its header; dollars mask with hidden balances. Day change includes options (shorts inverted) and crypto (midnight-ET boundary). Faucet gains `/option-positions` and `/crypto-positions`.

## Testing
- 359 unit tests pass; typecheck, production build, and lint clean on changed files.
- Option mappers + crypto quote mapper are pinned to live response fixtures; crypto position/order row mappings follow the documented shapes and are flagged for verification against the first live order.
- Gate verified end-to-end through the real hook endpoint: `place_crypto_order` and `exercise_option` both raise correctly parsed approval cards.