### PR TITLE
Add a sanitized failure_category to headless_run_finished

### DIFF
--- a/app/src/main/services/scheduler/wake/codex-strategy.ts
+++ b/app/src/main/services/scheduler/wake/codex-strategy.ts
@@ -1,4 +1,5 @@
 import { basename } from "node:path";
+import type { WakeFailureCategory } from "@shared/analytics";
 import { hostLog } from "../../../host/log";
 import type { AgentRegistry } from "../../agents/registry";
 import { analytics } from "../../analytics";
@@ -8,6 +9,7 @@ import {
   CodexServerUnavailableError,
   codexHomeFor,
 } from "../../harness/codex-app-server";
+import { classifyWakeFailure } from "./failure-category";
 import { formatWakePrompt } from "./prompt";
 import { clearSpawnMarker, writeSpawnMarker } from "./spawn-marker";
 import type { HeadlessExitReason, HeadlessWakeStrategy } from "./types";
@@ -44,7 +46,7 @@ export class CodexHeadlessStrategy implements HeadlessWakeStrategy {
     const startedAt = Date.now();
 
     let settled = false;
-    const settle = (reason: HeadlessExitReason) => {
+    const settle = (reason: HeadlessExitReason, failureCategory?: WakeFailureCategory) => {
       if (settled) return;
       settled = true;
       this.active.delete(agentId);
@@ -52,6 +54,7 @@ export class CodexHeadlessStrategy implements HeadlessWakeStrategy {
       analytics.track("headless_run_finished", {
         result: reason === "ok" ? "ok" : reason === "resumeFail" ? "resume_fail" : "spawn_fail",
         duration_ms: Math.max(0, Date.now() - startedAt),
+        ...(failureCategory ? { failure_category: failureCategory } : {}),
       });
       onExit(reason);
     };
@@ -91,7 +94,7 @@ export class CodexHeadlessStrategy implements HeadlessWakeStrategy {
         );
         if (result.outcome === "failed") {
           hostLog.warn("codex wake turn failed", agentId, result.error);
-          settle("resumeFail");
+          settle("resumeFail", classifyWakeFailure(String(result.error)));
         } else if (result.outcome === "interrupted" && !acked) {
           // Killed before delivery. A deliberate user Stop is handled by the
           // coordinator's `stopping` short-circuit regardless of reason; for the
@@ -104,7 +107,11 @@ export class CodexHeadlessStrategy implements HeadlessWakeStrategy {
       } catch (err) {
         hostLog.warn("codex wake run errored", agentId, String(err));
         analytics.trackError("wake", err, "caught");
-        settle(err instanceof CodexServerUnavailableError ? "spawnFail" : "resumeFail");
+        if (err instanceof CodexServerUnavailableError) {
+          settle("spawnFail");
+        } else {
+          settle("resumeFail", classifyWakeFailure(String(err)));
+        }
       }
     })();
   }

--- a/app/src/main/services/scheduler/wake/failure-category.test.ts
+++ b/app/src/main/services/scheduler/wake/failure-category.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { classifyWakeFailure } from "./failure-category";
+
+describe("classifyWakeFailure", () => {
+  test("unresumable-session lines from both harnesses", () => {
+    expect(
+      classifyWakeFailure(
+        "No conversation found with session ID 01a058e6-46da-7604-8712-4868fb29395f",
+      ),
+    ).toBe("unknown_session");
+    expect(classifyWakeFailure("Error: thread abc123 not found")).toBe("unknown_session");
+    expect(classifyWakeFailure("session was not found on disk")).toBe("unknown_session");
+    expect(classifyWakeFailure("unable to resume conversation")).toBe("unknown_session");
+  });
+
+  test("billing", () => {
+    expect(classifyWakeFailure("Credit balance is too low")).toBe("billing");
+    expect(classifyWakeFailure('API Error: 402 {"type":"error"}')).toBe("billing");
+  });
+
+  test("rate limits and usage caps", () => {
+    expect(classifyWakeFailure("Claude AI usage limit reached|1735689600")).toBe("rate_limit");
+    expect(
+      classifyWakeFailure('API Error: 429 {"type":"error","error":{"type":"rate_limit_error"}}'),
+    ).toBe("rate_limit");
+    expect(classifyWakeFailure("Overloaded")).toBe("rate_limit");
+    // A reset timestamp containing "402" as a digit substring must not read as a 402:
+    // the same real-world line would otherwise flip to billing depending on the epoch.
+    expect(classifyWakeFailure("Claude AI usage limit reached|1740234567")).toBe("rate_limit");
+  });
+
+  test("auth", () => {
+    expect(classifyWakeFailure("Invalid API key · Please run /login")).toBe("auth");
+    expect(classifyWakeFailure("OAuth token has expired. Please obtain a new token.")).toBe("auth");
+    expect(classifyWakeFailure('API Error: 401 {"type":"error"}')).toBe("auth");
+  });
+
+  test("session-not-found wins over other keywords in the same tail", () => {
+    // A tail can carry several lines; the unresumable-session signal is the most
+    // specific and must win over a generic auth-ish word later in the buffer.
+    expect(classifyWakeFailure("No conversation found with session ID x\nPlease run /login")).toBe(
+      "unknown_session",
+    );
+  });
+
+  test("unrecognized text fails closed to other", () => {
+    expect(classifyWakeFailure("")).toBe("other");
+    expect(classifyWakeFailure("segmentation fault")).toBe("other");
+    expect(classifyWakeFailure("TypeError: fetch failed")).toBe("other");
+    expect(classifyWakeFailure("spawn claude ENOENT")).toBe("other");
+  });
+
+  test("digit substrings and near-miss words don't fake a category", () => {
+    // Status codes are digit-bounded: durations, request ids, and byte counts in the
+    // 2000-char tail are full of 401/402/429 substrings that are not HTTP statuses.
+    expect(classifyWakeFailure("Request timed out after 40200ms")).toBe("other");
+    expect(classifyWakeFailure("stream error: retrying in 4013ms")).toBe("other");
+    expect(classifyWakeFailure("request_id: req_011CR4291abc failed with status 500")).toBe(
+      "other",
+    );
+    // "logging"/"dialog" must not read as "login".
+    expect(classifyWakeFailure("Error while logging to stderr file")).toBe("other");
+    expect(classifyWakeFailure("error dialog initialization failed")).toBe("other");
+  });
+
+  test("the fatal line wins over preceding noise lines in a multi-line tail", () => {
+    const tail =
+      "[debug] logging initialized\n[warn] retrying in 4013ms\nAPI Error: 429 rate_limit_error";
+    expect(classifyWakeFailure(tail)).toBe("rate_limit");
+  });
+});

--- a/app/src/main/services/scheduler/wake/failure-category.ts
+++ b/app/src/main/services/scheduler/wake/failure-category.ts
@@ -1,0 +1,43 @@
+import type { WakeFailureCategory } from "@shared/analytics";
+
+/**
+ * Classify a failed headless run's error text into the coarse `WakeFailureCategory`
+ * that ships on `headless_run_finished`. The input — the claude CLI's stderr tail or
+ * a codex turn error — never leaves the machine (it lands in the host log); only the
+ * returned category is tracked, so the patterns here can afford to be broad.
+ *
+ * Ordering matters where texts could match twice: an unresumable-session line is the
+ * most specific signal, so it wins; anything unrecognized falls through to `other`
+ * rather than guessing.
+ */
+export function classifyWakeFailure(text: string): WakeFailureCategory {
+  // "No conversation found with session ID <uuid>" (claude), "thread ... not found" (codex).
+  if (
+    /no conversation found|session[^\n]{0,40}not found|thread[^\n]{0,40}not found|unable to resume/i.test(
+      text,
+    )
+  ) {
+    return "unknown_session";
+  }
+  // "Credit balance is too low" — the incident that motivated stderr capture. HTTP
+  // status codes are digit-bounded: the tail is full of numbers (epoch reset stamps,
+  // `40200ms` durations, request ids) that must not read as a 402/429/401.
+  if (/credit balance|billing|payment required|(?<!\d)402(?!\d)/i.test(text)) {
+    return "billing";
+  }
+  // "Claude AI usage limit reached|<ts>", API 429s, overloaded upstream.
+  if (/usage limit|rate.?limit|(?<!\d)429(?!\d)|overloaded/i.test(text)) {
+    return "rate_limit";
+  }
+  // "Invalid API key · Please run /login", expired/revoked OAuth tokens. `login` is
+  // word-bounded ("/login", "log in") so a stray "logging ..." stderr line can't
+  // hijack the category.
+  if (
+    /api key|oauth|\blog ?in\b|authentication|unauthorized|(?<!\d)401(?!\d)|token[^\n]{0,20}(expired|revoked)|credentials/i.test(
+      text,
+    )
+  ) {
+    return "auth";
+  }
+  return "other";
+}

--- a/app/src/main/services/scheduler/wake/headless-strategy.ts
+++ b/app/src/main/services/scheduler/wake/headless-strategy.ts
@@ -1,11 +1,13 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import type { WakeFailureCategory } from "@shared/analytics";
 import { hostLog } from "../../../host/log";
 import type { AgentRegistry } from "../../agents/registry";
 import { analytics } from "../../analytics";
 import { harnessFor } from "../../harness";
 import type { LocalApiServer } from "../../local-api";
 import { buildAgentEnv } from "../../terminal/env";
+import { classifyWakeFailure } from "./failure-category";
 import { formatWakePrompt } from "./prompt";
 import { clearSpawnMarker, writeSpawnMarker } from "./spawn-marker";
 import type { HeadlessExitReason, HeadlessWakeStrategy } from "./types";
@@ -150,7 +152,7 @@ export class HeadlessRunStrategy implements HeadlessWakeStrategy {
 
     // Report the outcome exactly once (error and exit can't both meaningfully fire).
     let settled = false;
-    const settle = (reason: HeadlessExitReason) => {
+    const settle = (reason: HeadlessExitReason, failureCategory?: WakeFailureCategory) => {
       if (settled) return;
       settled = true;
       this.children.delete(agentId);
@@ -158,6 +160,7 @@ export class HeadlessRunStrategy implements HeadlessWakeStrategy {
       analytics.track("headless_run_finished", {
         result: reason === "ok" ? "ok" : reason === "resumeFail" ? "resume_fail" : "spawn_fail",
         duration_ms: Math.max(0, Date.now() - startedAt),
+        ...(failureCategory ? { failure_category: failureCategory } : {}),
       });
       onExit(reason);
     };
@@ -185,7 +188,7 @@ export class HeadlessRunStrategy implements HeadlessWakeStrategy {
         // row, flips the agent to `broken` (which pauses its scheduling). This is also the
         // heuristic that fires on a valid transient error like an exhausted credit balance:
         // that legitimately stops the agent until the user intervenes (top up + Restart).
-        settle("resumeFail");
+        settle("resumeFail", classifyWakeFailure(stderrTail));
       } else {
         settle("ok");
       }

--- a/app/src/shared/analytics.ts
+++ b/app/src/shared/analytics.ts
@@ -58,6 +58,21 @@ const orderSide = z.enum(["buy", "sell", "other"]);
 const orderType = z.enum(["market", "limit", "other"]);
 const orderKind = z.enum(["place", "cancel"]);
 
+/**
+ * Why a failed headless wake run failed, classified from the claude CLI's stderr tail
+ * (or the codex app-server's turn error) at the exit site. Only the category ships —
+ * the text it was derived from stays in the local host log. `other` is the fail-closed
+ * bucket for anything the classifier doesn't recognize.
+ */
+export const WakeFailureCategory = z.enum([
+  "auth",
+  "billing",
+  "rate_limit",
+  "unknown_session",
+  "other",
+]);
+export type WakeFailureCategory = z.infer<typeof WakeFailureCategory>;
+
 /** Subsystem an `app_error` originated in. */
 export const ErrorSubsystem = z.enum([
   "host",
@@ -188,6 +203,11 @@ export const TELEMETRY_EVENTS = {
   headless_run_finished: z.strictObject({
     result: z.enum(["ok", "resume_fail", "spawn_fail"]),
     duration_ms: z.number().int().nonnegative(),
+    /** Present only on failed runs whose exit site has error text to classify (a
+     *  claude resume-fail's stderr tail, a codex turn error) — spawn errors and
+     *  pre-delivery interrupts carry none. Without it a resume-fail streak that
+     *  breaks an agent is undiagnosable from telemetry (the text is local-only). */
+    failure_category: WakeFailureCategory.optional(),
   }),
   agent_marked_broken: z.strictObject({}),
   turn_limit_reached: z.strictObject({}),


### PR DESCRIPTION
A failed headless wake run previously reported only `result` and `duration_ms`. The reason it failed — the CLI's stderr line or the codex turn error — exists only in the local host log, so a resume-fail streak that flips an agent to `broken` was undiagnosable from the event alone.

This classifies the failure text at the exit site into a coarse enum and ships **only the category**:

- `failure_category`: `auth | billing | rate_limit | unknown_session | other` (optional, on failed runs with error text to classify) on `headless_run_finished`.
- `wake/failure-category.ts` does the classification, matched against real CLI error shapes (credit balance, usage limit, invalid/expired credentials, session/thread not found, 401/402/429). Unknown-session is the most specific signal and wins; anything unrecognized fails closed to `other`.
- Status codes are digit-bounded and the login pattern word-bounded, so epoch reset stamps, `40200ms` durations, request ids, and incidental "logging" lines in the 2000-char stderr tail can't fake a category.
- Both wake transports attach it on `resume_fail` — claude's strategy from the stderr tail, codex's from the turn/thrown error. `spawn_fail` is unchanged (already reported via `trackError`); codex's interrupted-before-delivery resumeFail carries no category, since it isn't a CLI failure.
- The telemetry allowlist keeps its structural guarantee: the new field is a `z.enum`, so no free text can pass.
- Unit tests cover every category, precedence, adversarial near-miss inputs, and the fail-closed default.

Gate: `bun test app/src` 316/316, typecheck clean, production build green, biome clean on the diff (the repo's one pre-existing `useHookAtTopLevel` false positive in `headless-strategy.ts` is untouched).