### PR TITLE
[posthog-monitor] broker: end the session when the grant is revoked, don't poll it forever

### DIFF
--- a/app/src/main/services/broker/connect.test.ts
+++ b/app/src/main/services/broker/connect.test.ts
@@ -1,5 +1,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { InvalidGrantError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { Account, OrderStatus, Portfolio, Position, Quote } from "@shared/broker";
 import { drizzle } from "drizzle-orm/bun-sqlite";
@@ -49,11 +51,18 @@ class FakeAdapter {
       pending.reject(new ConnectSuperseded());
     }
   }
-  /** Land call #i as connected. */
+  /** Land call #i as connected (and store tokens, as a real connect does). */
   succeed(i: number) {
     this.connected = true;
+    this.tokens = true;
     Object.assign(this.calls[i], { done: true });
     this.calls[i].resolve();
+  }
+  /** Stored tokens, so `svc.isAuthorized()` means something: true after a connect
+   *  lands, false after `reset()` drops them. */
+  tokens = false;
+  hasTokens() {
+    return this.tokens;
   }
   fail(i: number, err: unknown) {
     Object.assign(this.calls[i], { done: true });
@@ -67,6 +76,7 @@ class FakeAdapter {
     this.resets++;
     this.cancelConnect();
     this.connected = false;
+    this.tokens = false;
   }
   /** Set to make the service pick an account and start polling. */
   account: Account | null = null;
@@ -414,6 +424,75 @@ describe("BrokerService poll loop — network outages are not app errors", () =>
       error_code: "InternalError",
       source: "caught",
     });
+  });
+
+  test("a revoked grant ends the session instead of retrying it forever", async () => {
+    const { svc, adapter, client } = await connectedWithAccount();
+    // Production shape: the stored refresh token was revoked, so the first poll to use it
+    // throws and every later one throws identically. One install emitted 167 of these in
+    // 26 minutes — one per poll — while its UI still read `connected`.
+    adapter.pollScript = async () => {
+      throw new InvalidGrantError("token revoked");
+    };
+    expect(svc.isAuthorized()).toBe(true);
+    await poll(svc);
+    // Reported once, then the session is over: tokens dropped, so the panel shows the
+    // Connect CTA (a fresh consent) rather than pretending it can reconnect silently.
+    // The end itself is counted, so a stranded install is visible in telemetry.
+    expect(events(client)).toEqual(["app_error", "broker_session_ended"]);
+    expect(client.events[0].properties).toMatchObject({
+      subsystem: "broker",
+      error_name: "InvalidGrantError",
+      source: "caught",
+    });
+    expect(client.events[1].properties).toMatchObject({ reason: "invalid_grant" });
+    expect(svc.getStatus()).toBe("disconnected");
+    expect(adapter.resets).toBe(1);
+    expect(svc.isAuthorized()).toBe(false);
+
+    // And the loop is genuinely stopped — a further poll reports nothing new.
+    await poll(svc);
+    expect(events(client)).toEqual(["app_error", "broker_session_ended"]);
+  });
+
+  test("a revoked grant on the connect-time first poll ends the session without hanging connect()", async () => {
+    const { svc, adapter, client } = setup();
+    adapter.account = { accountNumber: "A1", agentic: true } as Account;
+    // `runConnect` awaits the first poll itself, while `inflight` still holds runConnect.
+    // Ending the session there via `disconnect()` — which awaits `inflight` — waited on
+    // itself: connect() never resolved, status stuck on `connected`, Reset hung too.
+    adapter.pollScript = async () => {
+      throw new InvalidGrantError("token revoked");
+    };
+    const c = svc.connect();
+    await tick();
+    adapter.succeed(0);
+    await c; // hung forever before the fix
+    expect(svc.getStatus()).toBe("disconnected");
+    expect(adapter.resets).toBe(1);
+    expect(events(client)).toEqual([
+      "broker_connect_started",
+      "broker_connected",
+      "app_error",
+      "broker_session_ended",
+    ]);
+    // No poller was started for the session that no longer exists…
+    expect((svc as unknown as { timer: unknown }).timer).toBeNull();
+    // …and the user's Reset still works.
+    await svc.disconnect();
+    expect(svc.getStatus()).toBe("disconnected");
+  });
+
+  test("a 401 mid-session is NOT treated as a dead grant — good tokens are kept", async () => {
+    const { svc, adapter, client } = await connectedWithAccount();
+    // `isReauthRequired` on the connect path also counts UnauthorizedError, but on the
+    // poll path a transient/endpoint-specific 401 must not cost the user their session.
+    adapter.pollScript = async () => {
+      throw new UnauthorizedError("nope");
+    };
+    await poll(svc);
+    expect(events(client)).toEqual(["app_error"]);
+    expect(svc.getStatus()).toBe("connected");
   });
 
   test("disconnect closes the books: no broker_online spanning a deliberate disconnect", async () => {

--- a/app/src/main/services/broker/index.ts
+++ b/app/src/main/services/broker/index.ts
@@ -21,7 +21,7 @@ import { analytics } from "../analytics";
 import { bus } from "../event-bus";
 import type { SettingsService } from "../settings";
 import { type BrokerAdapter, ConnectSuperseded } from "./adapter";
-import { brokerErrorCode, isTransientNetworkError } from "./network-error";
+import { brokerErrorCode, isDeadGrantError, isTransientNetworkError } from "./network-error";
 import { orderNotification, terminalTransition } from "./order-notify";
 
 /**
@@ -208,7 +208,9 @@ export class BrokerService {
       this.setStatus("connected");
       analytics.track("broker_connected");
       await this.pollOnce();
-      this.startPolling();
+      // The first poll can end the session itself (a dead grant → `forgetSession`):
+      // don't start a poller for a session that no longer exists.
+      if (this.status === "connected") this.startPolling();
     } catch (err) {
       // A newer connect took this one over (the user clicked Connect again): not a
       // failure — the newer attempt owns the status now, so leave it and report nothing.
@@ -235,13 +237,27 @@ export class BrokerService {
     // Let the in-flight connect unwind (a superseded one resolves quietly and leaves the
     // status alone — it's ours to set below).
     await this.inflight?.catch(() => {});
+    this.forgetSession();
+  }
+
+  /**
+   * Forget the session: stop polling, clear per-session state, status `disconnected`
+   * (the Connect CTA comes back; the next Connect is a fresh consent), drop the tokens.
+   * Shared by Reset and the poll loop's dead-grant path, which must call this and **not**
+   * `disconnect()`: that awaits `inflight`, and a dead grant can surface on the *first*
+   * poll, which `runConnect` awaits while `inflight` still holds `runConnect` — the await
+   * would wait on itself forever (status stuck on `connected`, Reset hung on it too).
+   * The token drop goes last: it is the one step that touches the DB, so status is
+   * already settled if it throws.
+   */
+  private forgetSession(): void {
     this.stopPolling();
-    this.adapter.reset();
     this.account = null;
     this.ledger.clear();
     this.offlineSince = null; // an outage doesn't span a deliberate disconnect
     this.failedPolls = 0;
     this.setStatus("disconnected");
+    this.adapter.reset();
   }
 
   /** True if we already have tokens and can connect without a browser. */
@@ -373,7 +389,15 @@ export class BrokerService {
       if (this.status !== "connected") return;
       // Network outage (laptop sleep/wake, Wi‑Fi blip) → broker_offline; else app_error.
       if (isTransientNetworkError(err)) this.noteOffline(err);
-      else analytics.trackError("broker", err, "caught", brokerErrorCode(err));
+      else {
+        analytics.trackError("broker", err, "caught", brokerErrorCode(err));
+        // A revoked grant never comes back (`isDeadGrantError`): end the session the way
+        // Reset does, instead of throwing this same error every 5–10 s over stale data.
+        if (isDeadGrantError(err)) {
+          this.forgetSession();
+          analytics.track("broker_session_ended", { reason: "invalid_grant" });
+        }
+      }
     } finally {
       this.polling = false;
     }

--- a/app/src/main/services/broker/network-error.ts
+++ b/app/src/main/services/broker/network-error.ts
@@ -1,3 +1,4 @@
+import { InvalidGrantError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { errorCodeOf } from "@shared/analytics";
 
@@ -45,6 +46,20 @@ export function isTransientNetworkError(err: unknown): boolean {
   const code = errorCodeOf(err);
   if (code && TRANSIENT_NETWORK_CODES.has(code)) return true;
   return err instanceof TypeError && err.message === "fetch failed";
+}
+
+/**
+ * Has the authorization server rejected our refresh token for good? `invalid_grant` is
+ * the one auth failure that is *never* worth retrying: the grant is expired or revoked,
+ * and no amount of waiting brings it back — only a fresh consent does.
+ *
+ * Deliberately narrower than `isReauthRequired` (`robinhood/client.ts`), which also
+ * counts a resource `UnauthorizedError`. That breadth is right when deciding whether to
+ * start a consent the user just asked for; it is wrong on the poll path, where a
+ * transient or endpoint-specific 401 would throw away credentials that still work.
+ */
+export function isDeadGrantError(err: unknown): boolean {
+  return err instanceof InvalidGrantError;
 }
 
 /**

--- a/app/src/shared/analytics.ts
+++ b/app/src/shared/analytics.ts
@@ -190,6 +190,13 @@ export const TELEMETRY_EVENTS = {
     offline_ms: z.number().int().nonnegative(),
     failed_polls: z.number().int().nonnegative(),
   }),
+  /**
+   * The poll loop found the stored grant revoked (`invalid_grant` on refresh) and ended
+   * the session itself: tokens dropped, status `disconnected`, Connect CTA back. A
+   * lifecycle event beside `broker_offline`/`broker_online`, so the broker funnel can
+   * count stranded installs without reading error dashboards for `InvalidGrantError`.
+   */
+  broker_session_ended: z.strictObject({ reason: z.enum(["invalid_grant"]) }),
 
   // autonomy
   schedule_created: z.strictObject({


### PR DESCRIPTION
## Evidence

One install on 0.2.6 is emitting `app_error` / `subsystem: broker` / `error_name: InvalidGrantError` continuously — a tuple not seen once in the prior 14 days. The shape says loop, not incident:

| | |
|---|---|
| started | 11:58:05 UTC, **still going** at last check (16:11) |
| total so far | **1,196 events over 4h13m** |
| cadence | one per poll — 360-369/hour when polling steadily, 60 of 60 minutes active |
| `broker_offline` emitted | **none** — it isn't a network fault |
| status during | still `connected` |
| reconnected | **no** — no `broker_connect_started`, no `broker_connected` at any point |

`frames` are entirely SDK-internal (`@modelcontextprotocol/sdk/auth.js`, `streamableHttp.js:326`), i.e. a refresh rejected with `invalid_grant` on a live client, not at connect time.

Not a 0.2.6 regression: the code path is identical in 0.2.5 (`b6d7218`). This is simply the first install whose refresh token died while telemetry was being watched.

## Root cause

The app already knows what a dead grant means. `isReauthRequired` (`robinhood/client.ts:175`) matches exactly this, and `connect()` responds by dropping the tokens so the next Connect starts clean (`:224-229`). `BrokerService.connect()` then reflects it as `disconnected` "so the UI shows the Connect CTA (which re-consents)" (`broker/index.ts:199-205`).

That check exists **only on the connect path** — but the connect path is not where this surfaces. The stored token is accepted at startup and rejected on first use, so the failure lands in `pollOnce`'s catch (`broker/index.ts:367-376`), which had three outcomes and no fourth for "this session is over":

1. `logPollFailure` — deduped for host.log (its comment already names "a revoked grant" as the motivating case).
2. `isTransientNetworkError` → `broker_offline`, deduped per outage.
3. everything else → `trackError`, then **poll again in 5-10s**.

So the adapter keeps believing it is connected, the outage is never tracked, the panel keeps showing stale cached data, and nothing invites the user to reconnect. Left alone it does not stop: at the observed rate that is ~8,600 events per day from one install.

## The change

`pollOnce`'s catch now ends a definitively dead session, reaching the same state `connect()` already reaches:

```ts
if (isTransientNetworkError(err)) this.noteOffline(err);
else {
  analytics.trackError("broker", err, "caught", brokerErrorCode(err));
  if (isDeadGrantError(err)) await this.endDeadSession();
}
```

- `isDeadGrantError` joins the other broker error classifiers in `network-error.ts`, keeping the SDK import out of the adapter-agnostic service.
- `endDeadSession()` delegates to `disconnect()` — session forgotten, polling stopped, status `disconnected`. Dropping the tokens is the point: keeping a revoked grant would leave `isAuthorized()` true and invite a silent reconnect that can only fail the same way.
- **Silent by design.** The user finds it disconnected the next time they look and clicks Connect. Notifying sooner is a separate product decision and is deliberately not in this PR.

**Scope is narrower than `isReauthRequired` on purpose.** That predicate also counts a resource `UnauthorizedError`, which is right when deciding whether to start a consent the user just asked for, and wrong on the poll path — a transient or endpoint-specific 401 would throw away credentials that still work. `invalid_grant` is the authorization server's permanent verdict; a 401 is not. Both behaviours are pinned by tests.

Side effect worth noting: the loop stopping means this fault emits **1 `app_error` instead of 1,196 and counting**, without touching the deliberate `"a non-network failure is still an app_error — every time"` invariant — a mapping bug thrown from our own code still reports on every poll, as intended.

## Verification

- `bun install --frozen-lockfile` — clean.
- `bun run typecheck` — clean.
- `bunx @biomejs/biome check` on the three changed files — clean. (There is no `lint` script in `app/package.json`; biome is the linter.)
- `bun test` from `app/`: **366 pass / 7 fail** with this change vs **364 pass / 7 fail** on the same base without it (measured by stashing). The +2 are the new tests; the 7 failures (AgentRegistry CLAUDE.md composition ×2, CodexClient app-server WebSocket ×5) are identical either way and unrelated to this diff. Note `bun test` must run from `app/` — the `@shared/*` alias doesn't resolve from the repo root.

Two tests added to `connect.test.ts`, using the existing `pollScript` harness: a revoked grant reports once then leaves `status: disconnected` / `isAuthorized(): false` with further polls silent; a mid-session 401 reports and stays `connected`.

## Risk

Low, and confined to one recovery path. No change to spawning, connecting, or the transient-outage path. The failure mode if the classification were ever wrong is a disconnect the user resolves with one click — and it is gated on the single error class whose meaning is "this credential is permanently void".

Branch note: this went to `posthog-monitor/dead-grant-disconnect` rather than my usual branch, which currently carries open PR #15 — pushing there would have silently rewritten that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128hXeESThVH1BrjUp2MbUP



---

## Review fixes (folded into the single commit)

Reviewed and taken over by @pranav. The diagnosis above stands; the routine's implementation had one blocking bug and a few gaps, fixed and squashed into this one commit (a follow-up simplification review then removed a speculative throw guard around the token drop):

- **Self-deadlock (blocking).** `endDeadSession()` called `disconnect()`, which awaits `inflight`. When the revoked grant surfaces on the *first* poll — which `runConnect` awaits before `startPolling()`, while `inflight` still holds `runConnect` — that await waited on itself: `connect()` never resolved, status stuck on `connected`, and Reset hung on the same await. Reproduced with a test (hung on the first commit, resolves on main). Now the teardown is inline (`forgetSession`, shared with `disconnect()`), and `runConnect` skips `startPolling()` if the first poll ended the session.
- **Telemetry.** The automatic end now emits `broker_session_ended {reason: invalid_grant}` after the single `app_error`, so a stranded install is countable instead of looking like one error that recovered.
- **Tests.** `FakeAdapter` had no `hasTokens()`, so the `isAuthorized()` assertion was vacuous (it passed with the session end stubbed out). It now tracks tokens through `succeed()`/`reset()`; the test also asserts `adapter.resets`. A new test pins the deadlock regression.

Verification on the branch: `bun test` from `app/` **374 pass / 0 fail**, `bun run typecheck` clean, biome clean on the changed files. `docs/ARCHITECTURE.md` (§6.6, §12.3) and `docs/TODO.md` are updated in the worktree copy and will be reconciled into the main checkout on merge.
