### PR TITLE
Add Windows desktop support

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,35 @@
+name: Release desktop (Windows)
+
+# Builds and publishes Windows NSIS installers + updater metadata to the same
+# draft GitHub Release used by the macOS workflow.
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Rebuild native modules for the Electron ABI
+        run: bun run --cwd app rebuild
+
+      - name: Build and publish Windows installers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          MAIN_VITE_POSTHOG_API_KEY: ${{ secrets.MAIN_VITE_POSTHOG_API_KEY }}
+        run: bun run --cwd app package -- --win --x64 --publish always

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <img src="assets/demo.png" width="820" alt="OpenTrade app — agent sidebar, live terminal, and portfolio panel" />
 </div>
 
-OpenTrade is a macOS app that enables agents to trade and react to the market autonomously. Agents execute trades in your [Robinhood Agentic Trading](https://robinhood.com/us/en/agentic-trading/) account through the official MCP. Set guardrails, monitors, and schedules so agents can trade 24/7 - all on your machine.
+OpenTrade is a macOS and Windows app that enables agents to trade and react to the market autonomously. Agents execute trades in your [Robinhood Agentic Trading](https://robinhood.com/us/en/agentic-trading/) account through the official MCP. Set guardrails, monitors, and schedules so agents can trade 24/7 - all on your machine.
 
 ## Features
 
@@ -73,9 +73,12 @@ Agents continue to get notified and work in the background, even if the app is c
 
 ## Install
 
-Download the latest `OpenTrade-<version>-arm64.dmg` from
-[Releases](https://github.com/OpenTradeOSS/OpenTrade/releases), open it, and drag OpenTrade to
-Applications. Requires an Apple Silicon Mac. The app auto-updates from GitHub Releases.
+Download the latest installer from [Releases](https://github.com/OpenTradeOSS/OpenTrade/releases):
+
+- macOS (Apple Silicon): `OpenTrade-<version>-arm64.dmg`; open it and drag OpenTrade to Applications.
+- Windows 10/11 (x64): `OpenTrade-<version>-x64-setup.exe`.
+
+The app auto-updates from GitHub Releases on both platforms.
 
 OpenTrade supports both Claude Code and Codex agents, so please install and sign into `claude`
 and/or `codex` CLI. An authenticated MCP connection to Robinhood via your agent is required, see
@@ -85,9 +88,14 @@ instructions.
 ## Build from source
 
 ```bash
-bun install                 # from repo root (bun workspaces)
-bun run --cwd app rebuild   # rebuild native modules for the Electron ABI (once)
-bun run --cwd app dev       # launch with HMR
+bun install           # from repo root (bun workspaces)
+bun run dev           # rebuild native modules for Electron, then launch with HMR
+```
+
+The same commands work in PowerShell on Windows. To create a local Windows installer:
+
+```powershell
+bun run --cwd app package -- --win --x64 --publish never
 ```
 
 ## Contributing

--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -31,6 +31,8 @@ extraResources:
     to: templates
   - from: ../resources
     to: resources
+  - from: build/icon.png
+    to: icon.png
 mac:
   category: public.app-category.finance
   target:
@@ -48,6 +50,18 @@ mac:
   # APPLE_TEAM_ID are in the environment; the Developer ID cert comes from
   # CSC_LINK / CSC_KEY_PASSWORD. See docs/PACKAGING.md.
   notarize: true
+win:
+  icon: build/icon.png
+  target:
+    - target: nsis
+      arch: [x64]
+  artifactName: ${productName}-${version}-${arch}-setup.${ext}
+nsis:
+  oneClick: false
+  perMachine: false
+  allowToChangeInstallationDirectory: true
+  createDesktopShortcut: always
+  createStartMenuShortcut: true
 dmg:
   title: OpenTrade ${version}
   contents:
@@ -61,4 +75,7 @@ publish:
   provider: github
   owner: OpenTradeOSS
   repo: OpenTrade
-npmRebuild: true
+# Native dependencies are prepared explicitly by `bun run rebuild` in release
+# workflows. node-pty ships Electron-compatible platform prebuilds; rebuilding it
+# unnecessarily requires optional Spectre C++ libraries on Windows builders.
+npmRebuild: false

--- a/app/package.json
+++ b/app/package.json
@@ -9,15 +9,17 @@
   "private": true,
   "main": "./out/main/index.js",
   "scripts": {
+    "predev": "bun run rebuild",
     "dev": "electron-vite dev --watch",
     "build": "electron-vite build",
     "start": "electron-vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.node.json",
     "prepackage": "node scripts/copy-native-modules.mjs",
     "package": "bun run prepackage && electron-vite build && electron-builder --config electron-builder.yml",
+    "package:windows": "bun run package -- --win --x64 --publish never",
     "package:signed": "set -a; [ -f ../.env ] && . ../.env; set +a; bun run package",
     "pack:dir": "bun run prepackage && electron-vite build && electron-builder --dir --config electron-builder.yml",
-    "rebuild": "electron-builder install-app-deps",
+    "rebuild": "electron-rebuild --force --only better-sqlite3",
     "make-icon": "node scripts/make-icon.mjs",
     "db:generate": "drizzle-kit generate"
   },
@@ -65,6 +67,7 @@
     "zustand": "5.0.12"
   },
   "devDependencies": {
+    "@electron/rebuild": "4.0.4",
     "@tailwindcss/vite": "4.2.2",
     "@types/better-sqlite3": "7.6.11",
     "@types/node": "22.10.2",

--- a/app/src/main/host/index.ts
+++ b/app/src/main/host/index.ts
@@ -52,9 +52,13 @@ import { HostTrpcServer } from "./trpc-server";
  * abandoned (both end in `OAUTH_TIMEOUT`).
  */
 function openExternal(url: string): void {
-  const cmd =
-    process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-  execFile(cmd, [url], (err) => {
+  const command =
+    process.platform === "darwin"
+      ? { file: "open", args: [url] }
+      : process.platform === "win32"
+        ? { file: "rundll32.exe", args: ["url.dll,FileProtocolHandler", url] }
+        : { file: "xdg-open", args: [url] };
+  execFile(command.file, command.args, (err) => {
     if (!err) return;
     hostLog.error("openExternal failed", String(err));
     analytics.trackError("broker", err, "caught", brokerErrorCode(err));

--- a/app/src/main/host/manifest.ts
+++ b/app/src/main/host/manifest.ts
@@ -107,10 +107,24 @@ const versionOf = (m: HostManifest): string => m.version ?? "0.0.0";
  * and the launcher's "Quit OpenTrade Completely" (§12.6).
  */
 export async function terminateHost(m: HostManifest): Promise<void> {
-  try {
-    process.kill(m.pid, "SIGTERM");
-  } catch {
-    // already gone
+  if (process.platform === "win32") {
+    // Windows does not deliver SIGTERM to arbitrary processes; Node terminates
+    // only the requested pid. taskkill /T also retires the host-owned Codex and
+    // PTY children instead of leaving them orphaned after an update/full quit.
+    await new Promise<void>((resolve) => {
+      const killer = spawn("taskkill.exe", ["/PID", String(m.pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      killer.once("error", () => resolve());
+      killer.once("close", () => resolve());
+    });
+  } else {
+    try {
+      process.kill(m.pid, "SIGTERM");
+    } catch {
+      // already gone
+    }
   }
   for (let i = 0; i < 50; i++) {
     if (!isAlive(m.pid)) break;
@@ -269,6 +283,7 @@ function spawnHost(hostEntry: string): void {
   const child = spawn(hostLauncherBinary(), [hostEntry], {
     detached: true,
     stdio: "ignore",
+    windowsHide: true,
     env: { ...process.env, ELECTRON_RUN_AS_NODE: "1", OPENTRADE_HOME },
   });
   child.unref();

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -53,13 +53,15 @@ const NOTIFY_TOGGLE: Record<NotificationKind, keyof AppSettings> = {
   update: "notifyUpdates",
 };
 
-/** The macOS menu bar item is a darwin-only affordance (elsewhere the app quits with its
- *  last window anyway). Toggled live by the `showInMenuBar` setting. Off when the host
+/** The macOS menu bar / Windows system tray keeps the launcher reachable while its
+ *  window is closed. Toggled live by the `showInMenuBar` setting. Off when the host
  *  never came up: there's nothing to monitor, and the BackendFailed screen tells the user
  *  to quit + reopen — ⌘Q must really quit for that recovery to work. */
 function menuBarEnabled(): boolean {
   return (
-    process.platform === "darwin" && liveSettings.showInMenuBar && (currentHost?.trpcPort ?? 0) > 0
+    (process.platform === "darwin" || process.platform === "win32") &&
+    liveSettings.showInMenuBar &&
+    (currentHost?.trpcPort ?? 0) > 0
   );
 }
 
@@ -205,6 +207,7 @@ function showAppNotification(kind: NotificationKind, title: string, body: string
 // Key Electron's per-instance state (including the single-instance lock) to this
 // home so parallel dev instances with distinct OPENTRADE_HOME don't collide.
 app.setPath("userData", join(OPENTRADE_HOME, "electron"));
+if (process.platform === "win32") app.setAppUserModelId("ai.exla.opentrade");
 
 if (!app.requestSingleInstanceLock()) {
   // Another OpenTrade GUI is already running for this home — defer to it and exit.
@@ -323,18 +326,19 @@ async function main() {
   });
 }
 
-// macOS: closing the window does not quit the app. The backend host is detached
+// macOS/Windows: closing the window does not quit the app while the status item is
+// enabled. The backend host is detached
 // and survives regardless, so agent sessions keep running with the GUI closed.
 // With the menu bar item on, "no window" also means "no dock icon" — the status
 // item *is* the app until the user opens it again (§12.6).
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
-    app.quit();
-    return;
-  }
   // Same guard as the quit intercept: only go dockless when there's a status item
   // left to reach the app through.
-  if (tray.visible) app.dock?.hide();
+  if (tray.visible) {
+    app.dock?.hide();
+    return;
+  }
+  app.quit();
 });
 
 // A signal is an explicit "exit" from outside — dev.sh, `kill`, the terminal's ^C, a

--- a/app/src/main/services/agents/registry.test.ts
+++ b/app/src/main/services/agents/registry.test.ts
@@ -147,6 +147,7 @@ describe("AgentRegistry — codex scaffold divergence", () => {
     const dir = r.agentDir(agent);
     const { existsSync, readFileSync } = await import("node:fs");
     const { basename, join } = await import("node:path");
+    const { OPENTRADE_HOME } = await import("../../db/client");
     const { codexHomeFor } = await import("../harness/codex-app-server");
     const codexHome = codexHomeFor(basename(dir));
 
@@ -193,28 +194,26 @@ describe("AgentRegistry — codex scaffold divergence", () => {
     expect(toml).toContain("[mcp_servers.opentrade]");
     expect(toml).not.toContain("OPENTRADE_TOKEN");
 
-    // Gate hooks: claude-compatible hooks.json + executable scripts, abs paths.
+    // Gate hooks: claude-compatible hooks.json + cross-platform Node runner.
     const hooks = JSON.parse(readFileSync(join(codexHome, "hooks.json"), "utf8"));
     const pre = hooks.hooks.PreToolUse[0];
     expect(pre.matcher).toBe(GATED_TOOL_MATCHER);
     // The regex form must actually match the prefixed tool names Claude Code sees.
     expect(new RegExp(`^${pre.matcher}$`).test("mcp__robinhood__place_crypto_order")).toBe(true);
     expect(new RegExp(`^${pre.matcher}$`).test("mcp__robinhood__get_equity_quotes")).toBe(false);
-    // The command is a shell string carrying the non-secret identifiers (codex
-    // cleans the hook env; the scripts recover port/token from the manifest).
-    expect(pre.hooks[0].command).toContain(join(codexHome, "hooks", "approval-gate.sh"));
-    expect(pre.hooks[0].command).toContain("OPENTRADE_AGENT_ID=");
-    expect(pre.hooks[0].command).toContain("OPENTRADE_HOME=");
+    // Codex cleans the hook env, so the non-secret agent/home identifiers are
+    // arguments and the runner recovers port/token from the host manifest.
+    expect(pre.hooks[0].command).toContain(join(codexHome, "hooks", "hook-runner.cjs"));
+    expect(pre.hooks[0].command).toContain(agent.id);
+    expect(pre.hooks[0].command).toContain(OPENTRADE_HOME);
     expect(pre.hooks[0].timeout).toBe(600);
-    expect(existsSync(join(codexHome, "hooks", "approval-gate.sh"))).toBe(true);
-    expect(existsSync(join(codexHome, "hooks", "order-result.sh"))).toBe(true);
+    expect(existsSync(join(codexHome, "hooks", "hook-runner.cjs"))).toBe(true);
     // Stop = the turn-ended stamp (codex's only status hook — it has no
     // Notification event). No matcher: fires on every turn end.
     const stop = hooks.hooks.Stop[0];
     expect(stop.matcher).toBeUndefined();
-    expect(stop.hooks[0].command).toContain(join(codexHome, "hooks", "status-notify.sh"));
-    expect(stop.hooks[0].command).toContain("OPENTRADE_AGENT_ID=");
-    expect(existsSync(join(codexHome, "hooks", "status-notify.sh"))).toBe(true);
+    expect(stop.hooks[0].command).toContain(join(codexHome, "hooks", "hook-runner.cjs"));
+    expect(stop.hooks[0].command).toContain("status");
 
     // codexHomeFor resolves under the REAL ~/.opentrade/cx (keyed by a hash, not
     // OPENTRADE_HOME — the socket-path length constraint), so this test writes outside
@@ -249,8 +248,9 @@ describe("AgentRegistry — codex scaffold divergence", () => {
     expect(settings.permissions.allow).toContain("mcp__robinhood__get_*");
     expect(settings.permissions.allow).toContain("mcp__robinhood__add_to_watchlist");
     expect(settings.permissions.allow).not.toContain("mcp__robinhood__place_crypto_order");
-    expect(pre.hooks[0].command).toContain(".claude/hooks/approval-gate.sh");
-    expect(existsSync(join(dir, ".claude", "hooks", "approval-gate.sh"))).toBe(true);
+    expect(pre.hooks[0].command).toContain("hook-runner.cjs");
+    expect(pre.hooks[0].command).toContain("approval");
+    expect(existsSync(join(dir, ".claude", "hooks", "hook-runner.cjs"))).toBe(true);
   });
 
   test("claude writeConfig GENERATES the gate config from a bare dir (build-independent + self-heal)", async () => {
@@ -267,9 +267,10 @@ describe("AgentRegistry — codex scaffold divergence", () => {
       expect(existsSync(join(dir, ".claude", "settings.json"))).toBe(false); // bare
       claudeHarness.writeConfig?.(dir, "agent-x");
       const settings = JSON.parse(readFileSync(join(dir, ".claude", "settings.json"), "utf8"));
-      expect(settings.hooks.PreToolUse[0].hooks[0].command).toContain("approval-gate.sh");
+      expect(settings.hooks.PreToolUse[0].hooks[0].command).toContain("hook-runner.cjs");
+      expect(settings.hooks.PreToolUse[0].hooks[0].command).toContain("approval");
       expect(settings.hooks.PreToolUse[0].hooks[0].timeout).toBe(600);
-      expect(existsSync(join(dir, ".claude", "hooks", "approval-gate.sh"))).toBe(true);
+      expect(existsSync(join(dir, ".claude", "hooks", "hook-runner.cjs"))).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/app/src/main/services/claude-config.test.ts
+++ b/app/src/main/services/claude-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   CLAUDE_DEFAULT_RETENTION_DAYS,
@@ -69,6 +69,6 @@ describe("claudeConfigDir", () => {
   });
 
   test("falls back to ~/.claude", () => {
-    expect(claudeConfigDir({}).endsWith("/.claude")).toBe(true);
+    expect(claudeConfigDir({})).toBe(join(homedir(), ".claude"));
   });
 });

--- a/app/src/main/services/event-bus.ts
+++ b/app/src/main/services/event-bus.ts
@@ -25,7 +25,7 @@ export interface AppEvents {
   "audit:changed": { agentId: string | null };
   /** A schedule/monitor was created, deleted, or fired; renderer re-queries the Scheduled view. */
   "scheduler:changed": { agentId: string | null };
-  /** A host-formatted macOS notification; the launcher relay gates it (per-kind
+  /** A host-formatted desktop notification; the launcher relay gates it (per-kind
    *  toggle, per-agent mute, window focus for wakes) and displays it (§12.4). */
   notify: HostNotification;
   /** The durable Recent ring buffer changed — full list, newest first (§12.6). */

--- a/app/src/main/services/harness/claude.ts
+++ b/app/src/main/services/harness/claude.ts
@@ -12,7 +12,9 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { GATED_TOOL_MATCHER, PREALLOWED_TOOL_PATTERNS } from "@shared/robinhood-tools";
+import { OPENTRADE_HOME } from "../../db/client";
 import { resolveHooksDir } from "../agents/paths";
+import { hookCommand } from "./hook-command";
 import { claudeConfigHasRobinhood } from "./robinhood-mcp";
 import type { Harness, ProbeResult, SessionMode } from "./types";
 
@@ -20,7 +22,7 @@ const execFileAsync = promisify(execFile);
 
 /**
  * The agent-dir `.claude/settings.json` that wires Claude Code's order gate: the
- * PreToolUse hook on the money-moving tools (→ `approval-gate.sh`, the approval card),
+ * PreToolUse hook on the money-moving tools (→ the cross-platform hook runner and approval card),
  * the PostToolUse order-result capture, and the Notification/Stop status hooks, plus
  * the allowlist for reads and cosmetic writes. The matcher and allowlist derive from
  * the classification table in `@shared/robinhood-tools` — the single place the gated
@@ -32,8 +34,9 @@ const execFileAsync = promisify(execFile);
  * `$CLAUDE_PROJECT_DIR` resolves to the agent folder, so the hooks stay agent-scoped
  * (never the user's global `~/.claude`).
  */
-const CLAUDE_SETTINGS_JSON = `${JSON.stringify(
-  {
+function claudeSettingsJson(hooksDir: string, agentId: string): string {
+  return `${JSON.stringify(
+    {
     $schema: "https://json.schemastore.org/claude-code-settings.json",
     enabledMcpjsonServers: ["robinhood", "opentrade"],
     permissions: {
@@ -47,7 +50,7 @@ const CLAUDE_SETTINGS_JSON = `${JSON.stringify(
           hooks: [
             {
               type: "command",
-              command: "$CLAUDE_PROJECT_DIR/.claude/hooks/approval-gate.sh",
+              command: hookCommand(hooksDir, "approval", agentId, OPENTRADE_HOME),
               timeout: 600,
             },
           ],
@@ -57,29 +60,39 @@ const CLAUDE_SETTINGS_JSON = `${JSON.stringify(
         {
           matcher: GATED_TOOL_MATCHER,
           hooks: [
-            { type: "command", command: "$CLAUDE_PROJECT_DIR/.claude/hooks/order-result.sh" },
+            {
+              type: "command",
+              command: hookCommand(hooksDir, "order-result", agentId, OPENTRADE_HOME),
+            },
           ],
         },
       ],
       Notification: [
         {
           hooks: [
-            { type: "command", command: "$CLAUDE_PROJECT_DIR/.claude/hooks/status-notify.sh" },
+            {
+              type: "command",
+              command: hookCommand(hooksDir, "status", agentId, OPENTRADE_HOME),
+            },
           ],
         },
       ],
       Stop: [
         {
           hooks: [
-            { type: "command", command: "$CLAUDE_PROJECT_DIR/.claude/hooks/status-notify.sh" },
+            {
+              type: "command",
+              command: hookCommand(hooksDir, "status", agentId, OPENTRADE_HOME),
+            },
           ],
         },
       ],
     },
-  },
-  null,
-  2,
-)}\n`;
+    },
+    null,
+    2,
+  )}\n`;
+}
 
 /**
  * `--dangerously-load-development-channels` is a VARIADIC flag (`<servers...>`):
@@ -116,7 +129,7 @@ export const claudeHarness: Harness = {
     return ["--session-id", sessionId, CHANNEL_ARG, ...(kickoff ? [kickoff] : [])];
   },
 
-  writeConfig(agentDir: string): void {
+  writeConfig(agentDir: string, agentId: string): void {
     // Generate the order-gate config in the agent's OWN .claude folder (project-scoped;
     // never the user's global ~/.claude). Runs at scaffold AND before every spawn, so it
     // heals agents that a clean CI build created without the (untracked) template
@@ -125,7 +138,7 @@ export const claudeHarness: Harness = {
     const claudeDir = join(agentDir, ".claude");
     const hooksDir = join(claudeDir, "hooks");
     mkdirSync(hooksDir, { recursive: true });
-    writeFileSync(join(claudeDir, "settings.json"), CLAUDE_SETTINGS_JSON);
+    writeFileSync(join(claudeDir, "settings.json"), claudeSettingsJson(hooksDir, agentId));
     const hooksSrc = resolveHooksDir();
     if (existsSync(hooksSrc)) {
       for (const file of readdirSync(hooksSrc)) {

--- a/app/src/main/services/harness/codex-app-server.test.ts
+++ b/app/src/main/services/harness/codex-app-server.test.ts
@@ -4,7 +4,7 @@ import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { WebSocketServer } from "ws";
-import { CodexClient } from "./codex-app-server";
+import { CodexClient, codexListenUrl } from "./codex-app-server";
 
 /**
  * A scripted stand-in for `codex app-server` on a unix socket: WS-over-UDS,
@@ -61,7 +61,17 @@ afterEach(() => {
 const THREAD = "t-1";
 const idleThread = { thread: { id: THREAD, status: { type: "idle" } } };
 
-describe("CodexClient against a scripted app-server", () => {
+test("normalizes Windows socket paths for the Codex listen URL", () => {
+  const sock = "C:\\Users\\Jane Doe\\app-server-control.sock";
+  expect(codexListenUrl(sock)).toBe("unix://C:/Users/Jane Doe/app-server-control.sock");
+});
+
+// Bun's Windows WebSocket implementation does not honor ws's createConnection
+// option, so these transport tests run on POSIX. The packaged Electron app uses
+// the npm ws implementation; its native Windows socket path is supplied directly.
+const describeSocketTransport = process.platform === "win32" ? describe.skip : describe;
+
+describeSocketTransport("CodexClient against a scripted app-server", () => {
   test("connect + request/response round-trip over the UDS WebSocket", async () => {
     const { sock } = mockServer({
       "thread/loaded/list": (msg, send) =>

--- a/app/src/main/services/harness/codex-app-server.ts
+++ b/app/src/main/services/harness/codex-app-server.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { createConnection } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import WebSocket from "ws";
@@ -27,6 +28,11 @@ import { hostLog } from "../../host/log";
 /** Control socket path for an agent's server, relative to its CODEX_HOME. */
 export function controlSocketPath(codexHome: string): string {
   return join(codexHome, "app-server-control", "app-server-control.sock");
+}
+
+/** Codex accepts forward-slash Windows paths in unix:// listen URLs. */
+export function codexListenUrl(sock: string): string {
+  return `unix://${sock.replaceAll("\\", "/")}`;
 }
 
 /**
@@ -167,7 +173,7 @@ export class CodexAppServerManager {
     }
 
     const startedAt = Date.now();
-    const child = spawn(this.binary, ["app-server", "--listen", `unix://${sock}`], {
+    const child = spawn(this.binary, ["app-server", "--listen", codexListenUrl(sock)], {
       env: { ...this.envFor(agentId, codexHome), CODEX_HOME: codexHome },
       stdio: ["ignore", "ignore", "pipe"],
     });
@@ -507,9 +513,12 @@ export class CodexClient {
     onServerRequest?: (method: string, params: unknown, signal: AbortSignal) => Promise<unknown>,
   ): Promise<CodexClient> {
     return new Promise((resolve, reject) => {
-      const ws = new WebSocket(`ws+unix://${sock}:/`, {
+      // ws+unix URLs use ':' as their socket/path separator, which conflicts
+      // with Windows drive letters. Supplying the native connection explicitly
+      // avoids that ambiguity and works for both AF_UNIX and Windows named pipes.
+      const ws = new WebSocket("ws://localhost/", {
+        createConnection: () => createConnection(sock),
         perMessageDeflate: false,
-        headers: { Host: "localhost" },
         handshakeTimeout: timeoutMs,
       });
       ws.once("open", () => resolve(new CodexClient(ws, onServerRequest)));

--- a/app/src/main/services/harness/codex.ts
+++ b/app/src/main/services/harness/codex.ts
@@ -21,6 +21,7 @@ import { hostLog } from "../../host/log";
 import { resolveAgentMcp, resolveHooksDir } from "../agents/paths";
 import { bus } from "../event-bus";
 import { type CodexAppServerManager, codexHomeFor } from "./codex-app-server";
+import { hookCommand } from "./hook-command";
 import { codexConfigHasRobinhood, ROBINHOOD_MCP_URL } from "./robinhood-mcp";
 import type { Harness, ProbeResult, SessionMode } from "./types";
 
@@ -81,7 +82,7 @@ function surfaceSessionSplit(agent: Agent, detail: string): void {
  *    raises an elicitation the backend answers through
  *    ApprovalService; no answer / client error / disconnect = Decline.
  *    (`"approve"` means PRE-approved in codex — never use it for order tools.)
- *  - redundancy: the same approval-gate.sh PreToolUse hook as claude (codex
+ *  - redundancy: the same approval PreToolUse hook as claude (codex
  *    accepts the identical deny JSON); hooks require trust, pre-established via
  *    a `hooks.state` batchWrite at server start.
  * `writeConfig` re-runs before every spawn, healing any tampering.
@@ -205,13 +206,32 @@ export function createCodexHarness(manager: CodexAppServerManager): Harness {
       // sync both ways (codex rewrites auth.json in place on refresh).
       const userAuth = join(homedir(), ".codex", "auth.json");
       const agentAuth = join(codexHome, "auth.json");
-      try {
-        if (existsSync(userAuth) && !lstatSync2(agentAuth)) symlinkSync(userAuth, agentAuth);
-      } catch (err) {
-        hostLog.warn("codex auth link failed (agent may need `codex login`)", String(err));
+      if (existsSync(userAuth)) {
+        try {
+          if (!lstatSync2(agentAuth)) symlinkSync(userAuth, agentAuth);
+        } catch (err) {
+          // Windows symlinks may require Developer Mode or elevation. A refreshed
+          // copy on every launch still gives the agent the user's current login.
+          try {
+            copyFileSync(userAuth, agentAuth);
+          } catch (copyErr) {
+            hostLog.warn(
+              "codex auth link/copy failed (agent may need `codex login`)",
+              String(err),
+              String(copyErr),
+            );
+          }
+        }
+        if (process.platform === "win32") {
+          try {
+            if (!lstatSync(agentAuth).isSymbolicLink()) copyFileSync(userAuth, agentAuth);
+          } catch {
+            // handled above on first creation; best effort on refresh
+          }
+        }
       }
 
-      // Gate scripts (same scripts as the claude scaffold — they just forward the
+      // Gate runner (shared with the claude scaffold — it forwards the
       // payload to the local gate endpoints).
       const hooksSrc = resolveHooksDir();
       if (existsSync(hooksSrc)) {
@@ -234,9 +254,8 @@ export function createCodexHarness(manager: CodexAppServerManager): Harness {
       // BOTH transports: the supervised app-server runs turns (and hooks) for
       // background wakes and the TUI's threads alike.
       // Hook commands are shell strings; codex runs hooks with a CLEANED env, so
-      // the non-secret identifiers ride the command itself and the scripts
+      // the non-secret identifiers ride the command itself and the runner
       // recover port/token from the host manifest ($OPENTRADE_HOME/host.json).
-      const hookEnv = `OPENTRADE_AGENT_ID='${agentId}' OPENTRADE_HOME='${OPENTRADE_HOME}'`;
       const hooks = {
         hooks: {
           PreToolUse: [
@@ -245,7 +264,7 @@ export function createCodexHarness(manager: CodexAppServerManager): Harness {
               hooks: [
                 {
                   type: "command",
-                  command: `${hookEnv} '${join(hooksDir, "approval-gate.sh")}'`,
+                  command: hookCommand(hooksDir, "approval", agentId, OPENTRADE_HOME),
                   timeout: 600,
                 },
               ],
@@ -257,7 +276,7 @@ export function createCodexHarness(manager: CodexAppServerManager): Harness {
               hooks: [
                 {
                   type: "command",
-                  command: `${hookEnv} '${join(hooksDir, "order-result.sh")}'`,
+                  command: hookCommand(hooksDir, "order-result", agentId, OPENTRADE_HOME),
                   timeout: 30,
                 },
               ],
@@ -268,7 +287,7 @@ export function createCodexHarness(manager: CodexAppServerManager): Harness {
               hooks: [
                 {
                   type: "command",
-                  command: `${hookEnv} '${join(hooksDir, "status-notify.sh")}'`,
+                  command: hookCommand(hooksDir, "status", agentId, OPENTRADE_HOME),
                   timeout: 10,
                 },
               ],

--- a/app/src/main/services/harness/hook-command.test.ts
+++ b/app/src/main/services/harness/hook-command.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { hookCommand } from "./hook-command";
+
+describe("hookCommand", () => {
+  test("uses cmd.exe syntax and quotes Windows paths", () => {
+    const command = hookCommand(
+      "C:\\Users\\Jane Doe\\hooks",
+      "approval",
+      "agent-1",
+      "C:\\Users\\Jane Doe\\OpenTrade Data",
+      "win32",
+    );
+    expect(command).toStartWith('set "ELECTRON_RUN_AS_NODE=1"&& ');
+    expect(command).toContain('"C:\\Users\\Jane Doe\\hooks\\hook-runner.cjs"');
+    expect(command).toEndWith('"approval" "agent-1" "C:\\Users\\Jane Doe\\OpenTrade Data"');
+  });
+
+  test("uses POSIX environment assignment and shell quoting", () => {
+    const command = hookCommand(
+      "/Users/jane/hooks",
+      "status",
+      "agent-2",
+      "/Users/jane/.opentrade",
+      "darwin",
+    );
+    expect(command).toStartWith("ELECTRON_RUN_AS_NODE=1 ");
+    expect(command).toContain(`'${join("/Users/jane/hooks", "hook-runner.cjs")}'`);
+    expect(command).toEndWith("'status' 'agent-2' '/Users/jane/.opentrade'");
+  });
+});
+
+describe("hook runner", () => {
+  const runner = join(import.meta.dir, "../../../../../resources/hooks/hook-runner.cjs");
+
+  test("fails approval closed when the local endpoint is unavailable", () => {
+    const result = spawnSync(process.execPath, [runner, "approval", "agent-1", join(import.meta.dir, "missing")], {
+      input: '{"hook_event_name":"PreToolUse"}',
+      encoding: "utf8",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+    expect(result.status).toBe(0);
+    const decision = JSON.parse(result.stdout);
+    expect(decision.hookSpecificOutput.permissionDecision).toBe("deny");
+  });
+
+  test("keeps observational hooks silent when the local endpoint is unavailable", () => {
+    const result = spawnSync(process.execPath, [runner, "status", "agent-1", join(import.meta.dir, "missing")], {
+      input: "{}",
+      encoding: "utf8",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("");
+  });
+});

--- a/app/src/main/services/harness/hook-command.ts
+++ b/app/src/main/services/harness/hook-command.ts
@@ -1,0 +1,34 @@
+import { join } from "node:path";
+
+export type HookKind = "approval" | "order-result" | "status";
+
+function quotePosix(value: string): string {
+  return `'${value.replaceAll("'", `'\"'\"'`)}'`;
+}
+
+function quoteCmd(value: string): string {
+  // Percent expansion still happens inside cmd.exe quotes. Doubling it preserves
+  // literal percent signs in user profile / agent paths.
+  return `"${value.replaceAll("%", "%%")}"`;
+}
+
+/**
+ * Build a shell command that runs a hook through the bundled Electron binary in
+ * Node mode. This avoids requiring Bash, curl, sed, or a separate Node install on
+ * the user's machine and therefore works in both POSIX shells and cmd.exe.
+ */
+export function hookCommand(
+  runnerDir: string,
+  kind: HookKind,
+  agentId: string,
+  opentradeHome: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const runner = join(runnerDir, "hook-runner.cjs");
+  const args = [process.execPath, runner, kind, agentId, opentradeHome].map(
+    platform === "win32" ? quoteCmd : quotePosix,
+  );
+  return platform === "win32"
+    ? `set "ELECTRON_RUN_AS_NODE=1"&& ${args.join(" ")}`
+    : `ELECTRON_RUN_AS_NODE=1 ${args.join(" ")}`;
+}

--- a/app/src/main/services/scheduler/monitor-runner.test.ts
+++ b/app/src/main/services/scheduler/monitor-runner.test.ts
@@ -7,7 +7,7 @@ describe("MonitorRunner", () => {
   test("each stdout line is a trigger, rate-limited to one per window", async () => {
     const triggers: string[] = [];
     const runner = new MonitorRunner({
-      command: "printf 'first\\nsecond\\n'; sleep 5",
+      command: `"${process.execPath}" -e "console.log('first'); console.log('second'); setTimeout(() => {}, 5000)"`,
       cwd: process.cwd(),
       env: { PATH: process.env.PATH ?? "" },
       onTrigger: (line) => triggers.push(line),
@@ -23,7 +23,7 @@ describe("MonitorRunner", () => {
   test("blank lines never trigger", async () => {
     const triggers: string[] = [];
     const runner = new MonitorRunner({
-      command: "printf '\\n   \\n'; sleep 5",
+      command: `"${process.execPath}" -e "console.log(''); console.log('   '); setTimeout(() => {}, 5000)"`,
       cwd: process.cwd(),
       env: { PATH: process.env.PATH ?? "" },
       onTrigger: (line) => triggers.push(line),

--- a/app/src/main/services/scheduler/scheduler.test.ts
+++ b/app/src/main/services/scheduler/scheduler.test.ts
@@ -385,7 +385,9 @@ describe("Scheduler CRUD", () => {
     const db = memDb();
     scheduler = makeSchedulerOn(db);
     // A command that emits one line immediately → one trigger → one fire.
-    const m = scheduler.createMonitor("agent1", { command: "printf 'go\\n'; sleep 5" });
+    const m = scheduler.createMonitor("agent1", {
+      command: `"${process.execPath}" -e "console.log('go'); setTimeout(() => {}, 5000)"`,
+    });
     await wait(300);
 
     const wakes = db.select().from(schema.wakes).all();

--- a/app/src/main/services/scheduler/wake/spawn-marker.test.ts
+++ b/app/src/main/services/scheduler/wake/spawn-marker.test.ts
@@ -84,7 +84,7 @@ describe("spawn-marker", () => {
   test("reconcile SIGTERMs a live orphan, then marks broken + clears", async () => {
     const reg = new FakeRegistry();
     reg.add("a2");
-    const child = spawn("sleep", ["30"]);
+    const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"]);
     await wait(20); // let it come up
     expect(child.pid && isAlive(child.pid)).toBe(true);
     writeSpawnMarker(marker({ agentId: "a2", pid: child.pid ?? 0 }), dir);

--- a/app/src/main/services/terminal/env.ts
+++ b/app/src/main/services/terminal/env.ts
@@ -4,7 +4,7 @@ import { OPENTRADE_HOME } from "../../db/client";
 
 /**
  * Build the environment for an agent's PTY. We inherit the app's env, ensure the
- * usual macOS bin dirs are on PATH (so `claude`, `git`, etc. resolve), and inject
+ * usual platform bin dirs are on PATH (so `claude`, `git`, etc. resolve), and inject
  * OPENTRADE_* identifiers. The hooks-server port/token (OPENTRADE_PORT /
  * OPENTRADE_TOKEN) are layered in by M3.
  *
@@ -28,15 +28,19 @@ export function buildAgentEnv(
   for (const key of opts?.stripEnvKeys ?? []) delete base[key];
 
   const home = homedir();
+  const platformPathDirs =
+    process.platform === "win32"
+      ? [
+          join(home, "AppData", "Roaming", "npm"),
+          join(home, "AppData", "Local", "Microsoft", "WinGet", "Links"),
+        ]
+      : ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"];
   const extraPathDirs = [
     join(home, ".opentrade", "bin"),
     join(home, ".local", "bin"),
     join(home, ".bun", "bin"),
     join(home, "bin"),
-    "/opt/homebrew/bin",
-    "/usr/local/bin",
-    "/usr/bin",
-    "/bin",
+    ...platformPathDirs,
   ];
   const currentPath = base.PATH ?? "";
   const merged = [...extraPathDirs, ...currentPath.split(delimiter)].filter(Boolean);

--- a/app/src/main/tray.ts
+++ b/app/src/main/tray.ts
@@ -1,9 +1,11 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import type { Agent, AgentStatus } from "@shared/agent";
 import type { RecentNotification } from "@shared/notify";
-import { Menu, type MenuItemConstructorOptions, nativeImage, Tray } from "electron";
+import { app, Menu, type MenuItemConstructorOptions, nativeImage, Tray } from "electron";
 
 /**
- * The macOS menu bar (status) item — §12.6.
+ * The macOS menu bar / Windows system tray status item — §12.6.
  *
  * A launcher-side monitor over the same relay stream that drives notifications:
  * per-agent status, the pending-approval count (also shown as the item's title so
@@ -56,10 +58,19 @@ const ICON_32 =
   "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAADpklEQVR42sWX24tVZRjGf7P3nqYZtUmIQC8GpAtBJIRwiETvkgwPieFVmgQp6IWCUYQHRMl/QJARVMQLEVT0QkJRBCPNQ2JMgYJW6KCjEB085szee3nzfPLM65q1tgT5wWLttfb7Pe/zPe/h+xa85NFW8n8VaNjzu8Bs3ScBrwMZcA+4AVwETgDf27yI0fKo6l4DlgFngWE5LLrqwCVgFdAVsF7Y+Uzgx+BgGBgCmlr5z8AA8CSHzBXgQ2FVWlB8hPM1ki6BNSVzem7oeTwwFpgMLAEO55DZbNiFJGq6b7HVZsApYAYwRjlw3cC35+BMA44EjL4yEmnlqzUhrWJDju1bwF9S5V+gRxK3h3ivUk4MCWvraDlRtSxv2ITPLX6JeWdQKQNWBAUr9nthIDEvj0Ri32+gaeWvCCyyXmS5sTsQwOaihSTbAWCcfI4YS835d3rXEWzGAu+oLK9Zkp60hcTRrvtBw/8yGlWAC2JYB6YbWBVYAOwDbsrGaz4DfihobKn8JgGPNP9X6xEA9IaMd5kvlzSdDDhX0llT+PbY3Pku2RyL3y5Jv0+yTTOgG3q3SU4TcNZCy08qpzHXDb4VyH2pcdqSJsV4gXIgjYmyz9SmixRIiztjClx2g6t6+Tfwmxn9CXySA1YDuoE7sjtTQKA9JHndsJ+NOyG2TSXcVIth6gPJyXjgbgGBNnP+NvCP8qxhHfI5AnX9cc+ct4+yhbsCZxXjSmhCqKJuhep5jsC10Lc/G8W5ExgHDIYq8NEJrAUemvML5mtECE4Ys3Mle3ibNaVBy51ebVbTgfWWV57IPcBtPfc76DdG4As5qZUQGGME0uY1kNMrmsA24c2y93scdKYlx+EWFeiy1TRyHD8W1ns2d6cpsjiWVr/+HAKmyFG1gECHKsUJXAUOaUufHEpxgkKVNqTXIvBKY3+0IAl9/GRzNuaErQK8qt+7c05IIww7tUkkiVaGLTWvt+83+16p0yEiFZv7sSn1B/BGbFoJcLYMh9QTPrIQVXJa6zJb1QHDqpl6s1SK6UCypOxUtNmyehhYHmyqtsV2hy76dcBcDDyw/rKjKMG99PpCY9ofkspBPg2254F12lW99x8MR7tRSywBbw1l9QDYqzPdBAvJVOVB05zFq89UK/02aDPwhWF3zKzz/aKj201zXg9fT4PKE1p1nidxN/CVvnKyFq/flUtvln0LvMjHaRfwPvCB+n2PnW4fqrlcAo4Bx7X9/qeP0/9lPAXLNXbyrktA3AAAAABJRU5ErkJggg==";
 
 function trayIcon() {
+  if (process.platform === "win32") {
+    const iconPath = app.isPackaged
+      ? join(process.resourcesPath, "icon.png")
+      : join(__dirname, "../../build/icon.png");
+    if (existsSync(iconPath)) {
+      const windowsIcon = nativeImage.createFromPath(iconPath);
+      if (!windowsIcon.isEmpty()) return windowsIcon.resize({ width: 16, height: 16 });
+    }
+  }
   const img = nativeImage.createEmpty();
   img.addRepresentation({ scaleFactor: 1, buffer: Buffer.from(ICON_16, "base64") });
   img.addRepresentation({ scaleFactor: 2, buffer: Buffer.from(ICON_32, "base64") });
-  img.setTemplateImage(true);
+  if (process.platform === "darwin") img.setTemplateImage(true);
   return img;
 }
 
@@ -97,6 +108,7 @@ export class AppTray {
     if (this.tray) return;
     this.tray = new Tray(trayIcon());
     this.tray.setToolTip("OpenTrade");
+    if (process.platform === "win32") this.tray.on("click", () => this.actions.openWindow());
     this.render();
     // Rows carry relative times ("2h ago"), which would otherwise freeze at whatever
     // the last data push rendered. macOS can't update an open menu, but every reopen
@@ -137,9 +149,15 @@ export class AppTray {
     if (!this.tray) return;
     // The pending-approval count rides next to the icon so the one actionable state is
     // visible without opening the menu (the dock badge is gone once the window closes).
-    this.tray.setTitle(this.pending > 0 ? String(this.pending) : "", {
-      fontType: "monospacedDigit",
-    });
+    if (process.platform === "darwin") {
+      this.tray.setTitle(this.pending > 0 ? String(this.pending) : "", {
+        fontType: "monospacedDigit",
+      });
+    } else {
+      this.tray.setToolTip(
+        this.pending > 0 ? `OpenTrade — ${this.pending} approval(s) pending` : "OpenTrade",
+      );
+    }
     this.tray.setContextMenu(Menu.buildFromTemplate(this.template()));
   }
 

--- a/app/src/main/updater.ts
+++ b/app/src/main/updater.ts
@@ -1,4 +1,4 @@
-// App updates for the packaged macOS app, via electron-updater against GitHub
+// App updates for the packaged macOS and Windows apps, via electron-updater against GitHub
 // Releases (publish config in electron-builder.yml bakes app-update.yml into the
 // build, which electron-updater reads — no feed URL needed here).
 //
@@ -78,8 +78,9 @@ function wireEvents(): void {
   // User-in-charge: never download or install without an explicit accept.
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
-  // Differential downloads are flaky on macOS zip updates; full download is robust.
-  autoUpdater.disableDifferentialDownload = true;
+  // Differential downloads are flaky on macOS zip updates; retain efficient
+  // blockmap downloads for the Windows NSIS updater.
+  autoUpdater.disableDifferentialDownload = process.platform === "darwin";
 
   autoUpdater.on("checking-for-update", () => {
     checking = true;
@@ -138,8 +139,9 @@ function errorMessage(err: unknown): string {
   // A release published without a `latest-mac.yml` asset surfaces as a feed error —
   // translate it into something actionable. Match only feed-specific messages (not a
   // bare "404", which can also be a missing zip mid-download).
-  if (/latest-mac\.yml|Cannot parse releases feed|Unable to find latest version/i.test(msg)) {
-    return "No update feed found on the latest release (missing latest-mac.yml). The release may still be building.";
+  if (/latest(?:-mac)?\.yml|Cannot parse releases feed|Unable to find latest version/i.test(msg)) {
+    const feed = process.platform === "darwin" ? "latest-mac.yml" : "latest.yml";
+    return `No update feed found on the latest release (missing ${feed}). The release may still be building.`;
   }
   return msg;
 }

--- a/app/src/main/window.ts
+++ b/app/src/main/window.ts
@@ -14,7 +14,7 @@ export function createMainWindow(host: HostEndpoint): BrowserWindow {
     minWidth: 900,
     minHeight: 600,
     show: false,
-    titleBarStyle: "hiddenInset",
+    ...(process.platform === "darwin" ? { titleBarStyle: "hiddenInset" as const } : {}),
     backgroundColor: "#121212",
     webPreferences: {
       preload: join(__dirname, "../preload/index.js"),

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -37,7 +37,7 @@ contextBridge.exposeInMainWorld("__opentradeUpdater", {
 });
 
 /**
- * Shell bridge from the MAIN process (menu bar item, §12.6): lets the launcher steer
+ * Shell bridge from the MAIN process (desktop status item, §12.6): lets the launcher steer
  * the renderer — today, "select this agent" after a tray-menu click. See shared/shell.ts.
  */
 contextBridge.exposeInMainWorld("__opentradeShell", {

--- a/app/src/renderer/App.tsx
+++ b/app/src/renderer/App.tsx
@@ -28,7 +28,7 @@ export function App() {
   // Gated off while the backend is down to match the disabled New Agent button.
   useShortcuts({ "create-agent": backendConnected ? openNewAgent : () => {} });
 
-  // A click on an agent in the macOS menu bar item (launcher-side) selects it here.
+  // A click on an agent in the desktop status item (launcher-side) selects it here.
   useShellSelection();
 
   // The launcher couldn't bring up the backend host (trpcPort===0), so nothing can

--- a/app/src/renderer/components/agents/NewAgentDialog.tsx
+++ b/app/src/renderer/components/agents/NewAgentDialog.tsx
@@ -17,6 +17,7 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useCreateAgent } from "../../hooks/useCreateAgent";
 import { useSettings } from "../../hooks/useSettings";
 import { trpc } from "../../lib/trpc";
+import { formatCombo } from "../../lib/shortcuts";
 import { cn } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui";
 import { HarnessGlyph } from "../icons/HarnessGlyph";
@@ -48,7 +49,7 @@ const ENVIRONMENTS: PickerOption[] = [
     value: "local",
     icon: <Laptop className="size-3.5" />,
     label: "Local",
-    hint: "Runs on this Mac",
+    hint: "Runs on this computer",
   },
   {
     value: "cloud",
@@ -254,7 +255,7 @@ function NewAgentForm() {
           />
         </div>
         <span className="px-1 text-[11px] text-muted-foreground/50">
-          {isPending ? "Creating…" : "⌘↵ to create"}
+          {isPending ? "Creating…" : `${formatCombo({ mod: true, key: "Enter" })} to create`}
         </span>
       </div>
     </form>

--- a/app/src/renderer/lib/shell.ts
+++ b/app/src/renderer/lib/shell.ts
@@ -3,7 +3,7 @@ import { useUIStore } from "../stores/ui";
 
 /**
  * Renderer side of the main-process shell bridge (`window.__opentradeShell`, exposed
- * by the preload; contract in shared/shell.ts). The macOS menu bar item (§12.6) lives
+ * by the preload; contract in shared/shell.ts). The desktop status item (§12.6) lives
  * in the launcher; when the user clicks an agent there, main opens/focuses the window
  * and asks us to select that agent. Two paths: a push for an already-mounted renderer,
  * and a pull on mount for the case where the click created the window (the push would

--- a/app/src/renderer/screens/Settings.tsx
+++ b/app/src/renderer/screens/Settings.tsx
@@ -117,10 +117,10 @@ function GeneralPanel() {
   return (
     <div className="space-y-8">
       <SettingsSection
-        title="Menu bar"
-        description="Keep an eye on your agents from the macOS menu bar."
+        title="Status area"
+        description="Keep an eye on your agents from the macOS menu bar or Windows system tray."
       >
-        <SettingsRow label="Show OpenTrade in the menu bar">
+        <SettingsRow label="Show OpenTrade in the status area">
           <SettingToggle
             checked={s.showInMenuBar}
             onChange={(showInMenuBar) => update.mutate({ showInMenuBar })}
@@ -459,7 +459,7 @@ function NotificationsPanel() {
 
   return (
     <div className="space-y-8">
-      <SettingsSection title="Notifications" description="macOS notifications from OpenTrade.">
+      <SettingsSection title="Notifications" description="Desktop notifications from OpenTrade.">
         <SettingsRow
           label="Agent wake-ups"
           hint="A timer or monitor fired and the agent started working. Shown only while OpenTrade is in the background."

--- a/app/src/shared/approval.ts
+++ b/app/src/shared/approval.ts
@@ -115,7 +115,7 @@ export const DecideInput = z.object({
 export type DecideInput = z.infer<typeof DecideInput>;
 
 /**
- * The PreToolUse hook decision the local server returns to `approval-gate.sh`,
+ * The PreToolUse hook decision the local server returns to the approval hook runner,
  * which echoes it verbatim to Claude Code. `allow` lets the order tool run;
  * `deny` blocks it and surfaces `permissionDecisionReason` to the agent.
  */

--- a/app/src/shared/notify.ts
+++ b/app/src/shared/notify.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 /**
- * The kinds of macOS notification OpenTrade shows. Each has a settings toggle
+ * The kinds of desktop notification OpenTrade shows. Each has a settings toggle
  * (§12.4) and rides the `notification_clicked` telemetry `kind` prop.
  */
 export const NotificationKind = z.enum(["wake", "order", "approval", "restricted", "update"]);

--- a/app/src/shared/settings.ts
+++ b/app/src/shared/settings.ts
@@ -41,7 +41,7 @@ export const AppSettings = z.object({
    *  through). Interactive sessions are unaffected either way. */
   backgroundAllowApiKey: z.boolean(),
 
-  // ---- macOS notifications (§12.4). All default on: the launcher gates display. ----
+  // ---- desktop notifications (§12.4). All default on: the launcher gates display. ----
   /** Notify when a cron/monitor wakes an agent (launcher shows it only while unfocused). */
   notifyWakes: z.boolean(),
   /** Notify when an agent-placed order reaches a terminal state (filled/rejected/…). */
@@ -56,7 +56,7 @@ export const AppSettings = z.object({
   notifyMutedAgents: z.array(z.string()),
 
   // ---- menu bar (§12.6) ----
-  /** Show the OpenTrade status item in the macOS menu bar and keep the launcher alive
+  /** Show the OpenTrade status item in the macOS menu bar / Windows system tray and keep the launcher alive
    *  there when the window is closed / ⌘Q'd, so agent status + notifications keep
    *  flowing while the app is "closed". On by default; off restores plain quit. */
   showInMenuBar: z.boolean(),

--- a/app/src/shared/shell.ts
+++ b/app/src/shared/shell.ts
@@ -1,7 +1,7 @@
 /**
  * Wire contract for the "shell" bridge between the Electron MAIN process and the
  * renderer — main-process UI chrome that needs to steer the renderer. Today that
- * is the macOS menu bar item (§12.6): clicking an agent in the tray menu opens the
+ * is the desktop status item (§12.6): clicking an agent in the tray menu opens the
  * window *and* selects that agent. Like the updater bridge (`shared/updater.ts`),
  * this is main-process state (the tray lives in the launcher, not the host), so it
  * rides `ipcRenderer` rather than tRPC.

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "app": {
       "name": "@opentrade/app",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.28.0",
         "@radix-ui/react-alert-dialog": "1.1.15",
@@ -56,6 +56,7 @@
         "zustand": "5.0.12",
       },
       "devDependencies": {
+        "@electron/rebuild": "4.0.4",
         "@tailwindcss/vite": "4.2.2",
         "@types/better-sqlite3": "7.6.11",
         "@types/node": "22.10.2",
@@ -866,7 +867,7 @@
 
     "isbinaryfile": ["isbinaryfile@5.0.7", "", {}, "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ=="],
 
-    "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+    "isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
@@ -976,7 +977,7 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
+    "node-abi": ["node-abi@4.31.0", "", { "dependencies": { "semver": "^7.6.3" } }, "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
@@ -1248,7 +1249,7 @@
 
     "web-vitals-soft-navs": ["web-vitals@6.0.0", "", {}, "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA=="],
 
-    "which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
+    "which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1293,8 +1294,6 @@
     "@electron/notarize/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
     "@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
-
-    "@electron/rebuild/node-abi": ["node-abi@4.31.0", "", { "dependencies": { "semver": "^7.6.3" } }, "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw=="],
 
     "@electron/universal/fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
 
@@ -1360,6 +1359,8 @@
 
     "app-builder-lib/ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
 
+    "app-builder-lib/which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
+
     "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
@@ -1388,13 +1389,13 @@
 
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
-
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "posthog-js/@posthog/core": ["@posthog/core@1.48.10", "", { "dependencies": { "@posthog/types": "^1.405.2" } }, "sha512-Y70zhdQFNMwHHZk9MW44MJUR1DyFm0Cn3DOtd+wQYnGv+kX+qc6CA+pBtEmZe2XD0K9uuOKiz2LJwzaq/wz0FA=="],
 
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
+
+    "prebuild-install/node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -1478,6 +1479,8 @@
 
     "app-builder-lib/@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "app-builder-lib/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "dir-compare/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
@@ -1497,8 +1500,6 @@
     "glob/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
 
     "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
-
-    "node-gyp/which/isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
     "@electron/asar/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/resources/hooks/hook-runner.cjs
+++ b/resources/hooks/hook-runner.cjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+"use strict";
+
+const { readFileSync } = require("node:fs");
+const { request } = require("node:http");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+const [kind, agentId = process.env.OPENTRADE_AGENT_ID || "", homeArg = ""] = process.argv.slice(2);
+const routes = {
+  approval: { path: "/hook/pretool-approval", timeout: 360_000 },
+  "order-result": { path: "/hook/order-result", timeout: 5_000 },
+  status: { path: "/hook/status", timeout: 5_000 },
+};
+const route = routes[kind];
+
+function deny(reason) {
+  process.stdout.write(
+    `${JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    })}\n`,
+  );
+}
+
+function endpoint() {
+  if (process.env.OPENTRADE_PORT && process.env.OPENTRADE_TOKEN) {
+    return { port: Number(process.env.OPENTRADE_PORT), token: process.env.OPENTRADE_TOKEN };
+  }
+  const home = homeArg || process.env.OPENTRADE_HOME || join(homedir(), ".opentrade");
+  try {
+    const manifest = JSON.parse(readFileSync(join(home, "host.json"), "utf8"));
+    return { port: Number(manifest.faucetPort), token: String(manifest.token || "") };
+  } catch {
+    return { port: 0, token: "" };
+  }
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+async function main() {
+  if (!route) return;
+  const input = await readStdin();
+  const { port, token } = endpoint();
+  if (!port || !token) {
+    if (kind === "approval") {
+      deny(
+        "OpenTrade is not running (no local endpoint); the approval gate fails closed. Open OpenTrade, then retry.",
+      );
+    }
+    return;
+  }
+
+  await new Promise((resolve) => {
+    let settled = false;
+    const finish = (response) => {
+      if (settled) return;
+      settled = true;
+      if (kind === "approval") {
+        if (response) process.stdout.write(`${response}\n`);
+        else deny("OpenTrade did not respond; the approval gate fails closed. Do not retry until the user confirms OpenTrade is running.");
+      }
+      resolve();
+    };
+    const req = request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: route.path,
+        method: "POST",
+        headers: {
+          "x-opentrade-token": token,
+          "x-opentrade-agent": agentId,
+          "content-type": "application/json",
+          "content-length": input.length,
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => finish(Buffer.concat(chunks).toString("utf8").trim()));
+      },
+    );
+    req.setTimeout(route.timeout, () => req.destroy(new Error("hook request timed out")));
+    req.on("error", () => finish(""));
+    req.end(input);
+  });
+}
+
+main().catch(() => {
+  if (kind === "approval") deny("OpenTrade hook failed; the approval gate fails closed.");
+});

--- a/templates/agents/AGENTS.prefix.codex.md
+++ b/templates/agents/AGENTS.prefix.codex.md
@@ -1,6 +1,6 @@
 # OpenTrade Agent
 
-You are a **trading agent** running inside **OpenTrade**, an open-source macOS app. You are a persistent Codex (OpenAI) session living in your own folder, embedded in OpenTrade's terminal, connected to Robinhood's Agentic Trading MCP. You trade **equities, options, and crypto** in the user's **dedicated, funded Robinhood agentic sub-account**.
+You are a **trading agent** running inside **OpenTrade**, an open-source macOS and Windows app. You are a persistent Codex (OpenAI) session living in your own folder, embedded in OpenTrade's terminal, connected to Robinhood's Agentic Trading MCP. You trade **equities, options, and crypto** in the user's **dedicated, funded Robinhood agentic sub-account**.
 
 Your job is to help one user run a trading strategy *they* design with you: research, watch markets, propose and place orders, and keep an honest journal of your reasoning. **Your specialty — and the discipline it demands — is described at the end of this document; read it as your operating mandate.**
 

--- a/templates/agents/CLAUDE.prefix.md
+++ b/templates/agents/CLAUDE.prefix.md
@@ -1,6 +1,6 @@
 # OpenTrade Agent
 
-You are a **trading agent** running inside **OpenTrade**, an open-source macOS app. You are a persistent Claude Code session living in your own folder, embedded in OpenTrade's terminal, connected to Robinhood's Agentic Trading MCP. You trade **equities, options, and crypto** in the user's **dedicated, funded Robinhood agentic sub-account**.
+You are a **trading agent** running inside **OpenTrade**, an open-source macOS and Windows app. You are a persistent Claude Code session living in your own folder, embedded in OpenTrade's terminal, connected to Robinhood's Agentic Trading MCP. You trade **equities, options, and crypto** in the user's **dedicated, funded Robinhood agentic sub-account**.
 
 Your job is to help one user run a trading strategy *they* design with you: research, watch markets, propose and place orders, and keep an honest journal of your reasoning. **Your specialty — and the discipline it demands — is described at the end of this document; read it as your operating mandate.**
 


### PR DESCRIPTION
## Summary

- add Windows x64/NSIS packaging, updater metadata, and a Windows release workflow
- make the launcher native on Windows (system tray, title bar, browser OAuth, AppUserModelID, and process-tree shutdown)
- replace Bash/curl-dependent agent hooks with a fail-closed cross-platform Node runner
- support Codex app-server sockets and auth setup on Windows, including environments without symlink privileges
- add Windows CLI paths, platform-neutral UI copy, docs, and cross-platform tests

## Validation

- `bun run typecheck`
- `bun run build`
- `bun run --cwd app rebuild`
- `bun run --cwd app package:windows`
- packaged `OpenTrade.exe` smoke test: native modules loaded and `/health` returned `{ "ok": true }`
- focused Windows tests: 23 passed
- full suite: 369 passed, 5 skipped, 2 pre-existing failures because the clean upstream checkout does not contain the ignored `templates/agents/{default,dca,momentum}/CLAUDE.md` specialty files expected by `registry.test.ts`

The local NSIS artifact produced successfully as `OpenTrade-0.2.6-x64-setup.exe` with its updater blockmap.
