### PR TITLE
Add an in-app feedback form

### DIFF
--- a/app/src/main/services/analytics/analytics.test.ts
+++ b/app/src/main/services/analytics/analytics.test.ts
@@ -12,6 +12,7 @@ import {
   TELEMETRY_EVENTS,
   templateOf,
 } from "@shared/analytics";
+import type { FeedbackDiagnostics, FeedbackInput } from "@shared/feedback";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import type { Db } from "../../db/client";
 import * as schema from "../../db/schema";
@@ -30,12 +31,20 @@ interface Captured {
   distinctId: string;
   event: string;
   properties?: Record<string, unknown>;
+  uuid?: string;
 }
 
 class FakeClient implements CaptureClient {
   events: Captured[] = [];
+  flushes = 0;
+  /** Set to make `flush()` reject — simulates a failed send. */
+  flushError: Error | null = null;
   capture(msg: Captured): void {
     this.events.push(msg);
+  }
+  async flush(): Promise<void> {
+    this.flushes++;
+    if (this.flushError) throw this.flushError;
   }
   async shutdown(): Promise<void> {}
 }
@@ -259,6 +268,131 @@ describe("AnalyticsService", () => {
     const err = Object.assign(new Error("x"), { code: "ECONNRESET" });
     svc.trackError("broker", err, "caught", undefined);
     expect(fake.events[0].properties).toMatchObject({ error_code: "ECONNRESET" });
+  });
+});
+
+const DIAG: FeedbackDiagnostics = {
+  app_version: "0.3.0",
+  platform: "darwin",
+  arch: "arm64",
+  os_release: "25.2.0",
+  electron_version: "40.1.0",
+  node_version: "22.20.0",
+  claude_version: "2.0.1 (Claude Code)",
+  codex_version: null,
+  host_uptime_sec: 120,
+  agent_count: 2,
+  agents_claude: 2,
+  agents_codex: 0,
+  agents_working: 1,
+  agents_needs_input: 0,
+  agents_awaiting_approval: 0,
+  agents_broken: 0,
+  agents_auto_mode: 0,
+  agents_turn_limited: 0,
+  agents_active_24h: 2,
+  schedules_enabled: 0,
+  monitors_enabled: 0,
+  broker_status: "connected",
+  broker_authorized: true,
+  broker_portfolio_age_sec: 5,
+  pending_approvals: 0,
+  telemetry_enabled: true,
+  default_approval_mode: "approve",
+  approval_timeout_sec: 300,
+  poll_interval_focused_sec: 5,
+  poll_interval_blurred_sec: 10,
+  headless_turn_limit_enabled: true,
+  max_headless_turns: 20,
+  max_headless_run_minutes: 30,
+  background_allow_api_key: false,
+};
+
+const INPUT: FeedbackInput = {
+  submissionId: "3f1c2b6e-8c1a-4a4b-9d0e-1a2b3c4d5e6f",
+  message: "The portfolio pane is blank after sleep.",
+  email: "someone@example.com",
+  includeDiagnostics: true,
+  view: "agents",
+};
+
+describe("AnalyticsService.sendFeedback", () => {
+  test("no client → unavailable, nothing captured", async () => {
+    const svc = makeService(new SettingsService(memDb()), null);
+    expect(svc.feedbackAvailable).toBe(false);
+    expect(await svc.sendFeedback(INPUT, DIAG)).toEqual({ ok: false });
+  });
+
+  test("sends under the install id even when telemetry is opted out; no usage event then", async () => {
+    const settings = new SettingsService(memDb());
+    settings.update({ telemetryEnabled: false });
+    const fake = new FakeClient();
+    const svc = makeService(settings, fake);
+    expect(svc.feedbackAvailable).toBe(true);
+
+    expect(await svc.sendFeedback(INPUT, DIAG)).toEqual({ ok: true });
+    expect(fake.flushes).toBe(1);
+    // Exactly one event: the feedback itself. `feedback_sent` is telemetry and gated off.
+    expect(fake.events.map((e) => e.event)).toEqual(["feedback_submitted"]);
+    const e = fake.events[0];
+    expect(e.distinctId).toBe(svc.anonymousId);
+    // The draft's id is the event uuid, so a retry after a timeout dedupes in PostHog.
+    expect(e.uuid).toBe(INPUT.submissionId);
+    expect(e.properties).toMatchObject({
+      message: INPUT.message,
+      email: INPUT.email,
+      view: "agents",
+      ...DIAG,
+    });
+    // The email must live on the event only — never on the person profile.
+    expect(e.properties).not.toHaveProperty("$set");
+    expect(e.properties).not.toHaveProperty("$set_once");
+  });
+
+  test("telemetry on → a separate categorical feedback_sent follows, carrying no text", async () => {
+    const fake = new FakeClient();
+    const svc = makeService(new SettingsService(memDb()), fake);
+    expect(await svc.sendFeedback(INPUT, DIAG)).toEqual({ ok: true });
+    expect(fake.events.map((e) => e.event)).toEqual(["feedback_submitted", "feedback_sent"]);
+    const usage = fake.events[1];
+    expect(usage.properties).toMatchObject({ with_email: true, with_diagnostics: true });
+    expect(usage.properties).not.toHaveProperty("message");
+    expect(usage.properties).not.toHaveProperty("email");
+  });
+
+  test("no email + toggle off → neither the email nor any diagnostics field is sent", async () => {
+    const fake = new FakeClient();
+    const svc = makeService(new SettingsService(memDb()), fake);
+    const input: FeedbackInput = {
+      submissionId: INPUT.submissionId,
+      message: "hi",
+      includeDiagnostics: false,
+      view: "settings",
+    };
+    expect(await svc.sendFeedback(input, null)).toEqual({ ok: true });
+    const props = fake.events[0].properties ?? {};
+    expect(Object.keys(props).sort()).toEqual(["message", "view"]);
+    expect(fake.events[1].properties).toMatchObject({ with_email: false, with_diagnostics: false });
+  });
+
+  test("a diagnostics block with an unknown field is dropped, the message still goes", async () => {
+    const fake = new FakeClient();
+    const svc = makeService(new SettingsService(memDb()), fake);
+    const bad = { ...DIAG, home_dir: "/Users/someone" } as unknown as FeedbackDiagnostics;
+    expect(await svc.sendFeedback(INPUT, bad)).toEqual({ ok: true });
+    const props = fake.events[0].properties ?? {};
+    expect(props).not.toHaveProperty("home_dir");
+    expect(props).not.toHaveProperty("app_version");
+    expect(props.message).toBe(INPUT.message);
+    expect(fake.events[1].properties).toMatchObject({ with_diagnostics: false });
+  });
+
+  test("a failed flush reports send_failed and emits no usage event", async () => {
+    const fake = new FakeClient();
+    fake.flushError = new Error("ECONNREFUSED");
+    const svc = makeService(new SettingsService(memDb()), fake);
+    expect(await svc.sendFeedback(INPUT, DIAG)).toEqual({ ok: false });
+    expect(fake.events.map((e) => e.event)).toEqual(["feedback_submitted"]);
   });
 });
 

--- a/app/src/main/services/analytics/index.ts
+++ b/app/src/main/services/analytics/index.ts
@@ -10,6 +10,11 @@ import {
   type TelemetryEvent,
   type TelemetryProps,
 } from "@shared/analytics";
+import {
+  type FeedbackDiagnostics,
+  FeedbackDiagnostics as FeedbackDiagnosticsSchema,
+  type FeedbackInput,
+} from "@shared/feedback";
 import type { AppSettings } from "@shared/settings";
 import { PostHog } from "posthog-node";
 import type { z } from "zod";
@@ -26,9 +31,20 @@ const POSTHOG_HOST = "https://r.exla.ai";
  * so tests can inject a fake without the SDK or a network path.
  */
 export interface CaptureClient {
-  capture(msg: { distinctId: string; event: string; properties?: Record<string, unknown> }): void;
+  capture(msg: {
+    distinctId: string;
+    event: string;
+    properties?: Record<string, unknown>;
+    uuid?: string;
+  }): void;
+  /** Resolve once queued events are on the wire (rejects on a failed send). Only the
+   *  feedback path awaits it — telemetry stays fire-and-forget. */
+  flush(): Promise<void>;
   shutdown(timeoutMs?: number): Promise<void>;
 }
+
+/** How long `sendFeedback` waits for the flush before reporting failure. */
+const FEEDBACK_FLUSH_TIMEOUT_MS = 8000;
 
 /** Non-telemetry AppSettings keys we surface as `setting_changed`. */
 const REPORTABLE_SETTING_KEYS = [
@@ -196,6 +212,67 @@ export class AnalyticsService {
       source,
       ...(frames.length ? { frames } : {}),
     });
+  }
+
+  /** Whether this build can send feedback at all — i.e. a PostHog client exists. The
+   *  telemetry opt-out is deliberately NOT consulted (see `sendFeedback`). */
+  get feedbackAvailable(): boolean {
+    return this.client !== null;
+  }
+
+  /**
+   * Send an in-app feedback submission (§12.8) as one `feedback_submitted` event. The
+   * one capture that bypasses `track()`: free text, so not allowlisted, and **not gated
+   * by `telemetryEnabled`** — clicking Send is the consent. Same anonymous install id;
+   * nothing `$set` on the person profile. Awaits the flush so the UI gets a real
+   * sent/failed outcome.
+   */
+  async sendFeedback(
+    input: FeedbackInput,
+    diagnostics: FeedbackDiagnostics | null,
+  ): Promise<{ ok: boolean }> {
+    const client = this.client;
+    if (!client) return { ok: false };
+
+    // Wire boundary for the diagnostics block: out-of-schema → dropped, message still goes.
+    const diag = diagnostics ? FeedbackDiagnosticsSchema.safeParse(diagnostics) : null;
+    if (diag && !diag.success) hostLog.warn("feedback: diagnostics failed schema, sending without");
+    const block = diag?.success ? diag.data : null;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      client.capture({
+        // The draft's id: a retry after a timed-out flush (posthog-node keeps retrying in
+        // the background) reuses it, so PostHog dedupes instead of storing two copies.
+        uuid: input.submissionId,
+        distinctId: this.distinctId,
+        event: "feedback_submitted",
+        properties: {
+          message: input.message,
+          ...(input.email ? { email: input.email } : {}),
+          view: input.view,
+          ...(block ?? {}),
+        },
+      });
+      await Promise.race([
+        client.flush(),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error("flush timeout")), FEEDBACK_FLUSH_TIMEOUT_MS);
+        }),
+      ]);
+    } catch (err) {
+      hostLog.warn(`feedback: send failed: ${String(err)}`);
+      return { ok: false };
+    } finally {
+      clearTimeout(timer);
+    }
+
+    // The usage signal, through the normal allowlist + opt-out gate.
+    this.track("feedback_sent", {
+      with_email: Boolean(input.email),
+      with_diagnostics: block !== null,
+    });
+    return { ok: true };
   }
 
   /** Flush pending events and stop listening. Bounded so host shutdown can't hang. */

--- a/app/src/main/services/feedback/diagnostics.test.ts
+++ b/app/src/main/services/feedback/diagnostics.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import type { Agent } from "@shared/agent";
+import { FeedbackDiagnostics } from "@shared/feedback";
+import { DEFAULT_SETTINGS } from "@shared/settings";
+import { buildDiagnostics, cliVersionOf, type DiagnosticsValues } from "./diagnostics";
+
+const NOW = 1_800_000_000_000;
+
+function agent(overrides: Partial<Agent>): Agent {
+  return {
+    harness: "claude",
+    status: "idle",
+    executionState: "offline",
+    approvalMode: "approve",
+    headlessTurnsUsed: 0,
+    turnLimitEnabled: true,
+    lastActiveAt: null,
+    ...overrides,
+  } as Agent;
+}
+
+const VALUES: DiagnosticsValues = {
+  agents: [
+    // working, active today, auto-mode
+    agent({
+      status: "working",
+      executionState: "interactive",
+      approvalMode: "auto",
+      lastActiveAt: NOW - 1000,
+    }),
+    // broken, budget spent, last active a week ago
+    agent({ executionState: "broken", headlessTurnsUsed: 99, lastActiveAt: NOW - 7 * 86_400_000 }),
+    // codex, waiting on an approval
+    agent({ harness: "codex", status: "awaiting-approval" }),
+  ],
+  crons: 4,
+  monitors: 1,
+  brokerStatus: "connected",
+  brokerAuthorized: true,
+  portfolioFetchedAt: NOW - 12_500,
+  pendingApprovals: 2,
+  settings: { ...DEFAULT_SETTINGS, telemetryEnabled: false },
+  claudeVersion: "2.0.1 (Claude Code)",
+  codexVersion: null,
+};
+
+describe("buildDiagnostics", () => {
+  test("derives counts, ages and settings; the result satisfies the strict schema", () => {
+    const d = buildDiagnostics(VALUES, NOW);
+    expect(FeedbackDiagnostics.safeParse(d).success).toBe(true);
+    expect(d).toMatchObject({
+      claude_version: "2.0.1 (Claude Code)",
+      codex_version: null,
+      agent_count: 3,
+      agents_claude: 2,
+      agents_codex: 1,
+      agents_working: 1,
+      agents_needs_input: 0,
+      agents_awaiting_approval: 1,
+      agents_broken: 1,
+      agents_auto_mode: 1,
+      agents_turn_limited: 1,
+      agents_active_24h: 1,
+      schedules_enabled: 4,
+      monitors_enabled: 1,
+      broker_status: "connected",
+      broker_authorized: true,
+      broker_portfolio_age_sec: 12,
+      pending_approvals: 2,
+      telemetry_enabled: false,
+      max_headless_turns: DEFAULT_SETTINGS.maxHeadlessTurns,
+    });
+  });
+
+  test("null portfolio age before the first fetch; turn-limited is 0 when the feature is off", () => {
+    const d = buildDiagnostics(
+      {
+        ...VALUES,
+        portfolioFetchedAt: null,
+        settings: { ...DEFAULT_SETTINGS, headlessTurnLimitEnabled: false },
+      },
+      NOW,
+    );
+    expect(d.broker_portfolio_age_sec).toBeNull();
+    expect(d.agents_turn_limited).toBe(0);
+  });
+});
+
+describe("cliVersionOf", () => {
+  test("keeps the first line of a version banner, drops anything outside the charset", () => {
+    expect(cliVersionOf({ found: true, version: "2.0.1 (Claude Code)\nsecond line" })).toBe(
+      "2.0.1 (Claude Code)",
+    );
+    expect(cliVersionOf({ found: true, version: "/Users/someone/bin/claude 2.0" })).toBeNull();
+    expect(cliVersionOf({ found: false, version: null })).toBeNull();
+  });
+});

--- a/app/src/main/services/feedback/diagnostics.ts
+++ b/app/src/main/services/feedback/diagnostics.ts
@@ -1,0 +1,82 @@
+import { release } from "node:os";
+import type { Agent } from "@shared/agent";
+import type { BrokerConnectionStatus } from "@shared/broker";
+import type { FeedbackDiagnostics } from "@shared/feedback";
+import type { AppSettings } from "@shared/settings";
+
+export interface DiagnosticsValues {
+  agents: Agent[];
+  /** Enabled cron schedules / monitors across every agent. */
+  crons: number;
+  monitors: number;
+  brokerStatus: BrokerConnectionStatus;
+  brokerAuthorized: boolean;
+  /** `fetchedAt` of the cached portfolio snapshot, or null before the first fetch. */
+  portfolioFetchedAt: number | null;
+  pendingApprovals: number;
+  settings: AppSettings;
+  claudeVersion: string | null;
+  codexVersion: string | null;
+}
+
+const DAY_MS = 86_400_000;
+
+/** First line of a harness `--version` probe if it fits the schema's charset, else null
+ *  (a multi-line banner or a path collapses to null rather than failing the block). */
+export function cliVersionOf(probe: { found: boolean; version: string | null }): string | null {
+  const first = probe.version?.split("\n")[0].trim() ?? "";
+  return probe.found && /^[\w.\-+ ()]{1,64}$/.test(first) ? first : null;
+}
+
+/** The "Include anonymous app data" block (§12.8) — counts, enums, versions, tunables. */
+export function buildDiagnostics(v: DiagnosticsValues, now = Date.now()): FeedbackDiagnostics {
+  const s = v.settings;
+  const countIf = (pred: (a: Agent) => boolean) => v.agents.filter(pred).length;
+  return {
+    app_version: process.env.OPENTRADE_VERSION ?? "dev",
+    platform: process.platform,
+    arch: process.arch,
+    os_release: release(),
+    electron_version: process.versions.electron ?? null,
+    node_version: process.versions.node,
+    claude_version: v.claudeVersion,
+    codex_version: v.codexVersion,
+    host_uptime_sec: Math.floor(process.uptime()),
+
+    agent_count: v.agents.length,
+    agents_claude: countIf((a) => a.harness === "claude"),
+    agents_codex: countIf((a) => a.harness === "codex"),
+    agents_working: countIf((a) => a.status === "working"),
+    agents_needs_input: countIf((a) => a.status === "needs-input"),
+    agents_awaiting_approval: countIf((a) => a.status === "awaiting-approval"),
+    agents_broken: countIf((a) => a.executionState === "broken"),
+    agents_auto_mode: countIf((a) => a.approvalMode === "auto"),
+    agents_turn_limited: countIf(
+      (a) =>
+        s.headlessTurnLimitEnabled &&
+        a.turnLimitEnabled &&
+        a.headlessTurnsUsed >= s.maxHeadlessTurns,
+    ),
+    agents_active_24h: countIf((a) => a.lastActiveAt !== null && now - a.lastActiveAt < DAY_MS),
+    schedules_enabled: v.crons,
+    monitors_enabled: v.monitors,
+
+    broker_status: v.brokerStatus,
+    broker_authorized: v.brokerAuthorized,
+    broker_portfolio_age_sec:
+      v.portfolioFetchedAt === null
+        ? null
+        : Math.max(0, Math.floor((now - v.portfolioFetchedAt) / 1000)),
+    pending_approvals: v.pendingApprovals,
+
+    telemetry_enabled: s.telemetryEnabled,
+    default_approval_mode: s.defaultApprovalMode,
+    approval_timeout_sec: s.approvalTimeoutSec,
+    poll_interval_focused_sec: s.pollIntervalFocusedSec,
+    poll_interval_blurred_sec: s.pollIntervalBlurredSec,
+    headless_turn_limit_enabled: s.headlessTurnLimitEnabled,
+    max_headless_turns: s.maxHeadlessTurns,
+    max_headless_run_minutes: s.maxHeadlessRunMinutes,
+    background_allow_api_key: s.backgroundAllowApiKey,
+  };
+}

--- a/app/src/main/trpc/routers/feedback.ts
+++ b/app/src/main/trpc/routers/feedback.ts
@@ -1,0 +1,36 @@
+import { FeedbackInput } from "@shared/feedback";
+import { analytics } from "../../services/analytics";
+import { buildDiagnostics, cliVersionOf } from "../../services/feedback/diagnostics";
+import { harnessFor } from "../../services/harness";
+import { buildAgentEnv } from "../../services/terminal/env";
+import { publicProcedure, router } from "../trpc";
+
+/** The in-app feedback form's backend (§12.8). */
+export const feedbackRouter = router({
+  available: publicProcedure.query(() => ({ available: analytics.feedbackAvailable })),
+
+  send: publicProcedure.input(FeedbackInput).mutation(async ({ ctx, input }) => {
+    let diagnostics = null;
+    if (input.includeDiagnostics) {
+      // Same PATH agents get, so the CLIs are found wherever they live.
+      const env = buildAgentEnv("feedback");
+      const [claude, codex] = await Promise.all([
+        harnessFor("claude").probe(env),
+        harnessFor("codex").probe(env),
+      ]);
+      diagnostics = buildDiagnostics({
+        agents: ctx.registry.list(),
+        crons: ctx.scheduler.listAllCron().length,
+        monitors: ctx.scheduler.listAllMonitors().length,
+        brokerStatus: ctx.broker.getStatus(),
+        brokerAuthorized: ctx.broker.isAuthorized(),
+        portfolioFetchedAt: ctx.broker.getCachedPortfolio()?.fetchedAt ?? null,
+        pendingApprovals: ctx.approvals.pendingCount(),
+        settings: ctx.settings.get(),
+        claudeVersion: cliVersionOf(claude),
+        codexVersion: cliVersionOf(codex),
+      });
+    }
+    return analytics.sendFeedback(input, diagnostics);
+  }),
+});

--- a/app/src/main/trpc/routers/index.ts
+++ b/app/src/main/trpc/routers/index.ts
@@ -4,6 +4,7 @@ import { agentsRouter } from "./agents";
 import { analyticsRouter } from "./analytics";
 import { approvalsRouter } from "./approvals";
 import { brokerRouter } from "./broker";
+import { feedbackRouter } from "./feedback";
 import { notificationsRouter } from "./notifications";
 import { onboardingRouter } from "./onboarding";
 import { scheduleRouter } from "./schedule";
@@ -22,6 +23,7 @@ export const appRouter = router({
   settings: settingsRouter,
   schedule: scheduleRouter,
   analytics: analyticsRouter,
+  feedback: feedbackRouter,
   notifications: notificationsRouter,
 });
 

--- a/app/src/renderer/components/feedback/FeedbackButton.tsx
+++ b/app/src/renderer/components/feedback/FeedbackButton.tsx
@@ -1,0 +1,225 @@
+import { FEEDBACK_MESSAGE_MAX, FeedbackInput } from "@shared/feedback";
+import { Check, ExternalLink, Loader2, MessageSquare, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { trpc } from "../../lib/trpc";
+import { cn } from "../../lib/utils";
+import { useConnectionStore } from "../../stores/connection";
+import { useFeedbackStore } from "../../stores/feedback";
+import { useUIStore } from "../../stores/ui";
+import { SettingToggle } from "../settings/SettingToggle";
+import { OPENTRADE_DISCORD_URL } from "../settings/TelemetryOptOutDialog";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { Textarea } from "../ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+
+/** How long the trigger icon shows the green check after a successful send. */
+const SENT_FLASH_MS = 3000;
+
+/**
+ * The in-app feedback entry point (§12.8), at the right end of the `RightPanel` footer.
+ * The popover is `modal` because xterm stops bubble-phase events, so a non-modal
+ * outside-click dismiss never fires over the terminal.
+ */
+export function FeedbackButton() {
+  const [open, setOpen] = useState(false);
+  // After a send the popover closes at once and the icon crossfades to a green check.
+  const [justSent, setJustSent] = useState(false);
+  const backendConnected = useConnectionStore((s) => s.backendConnected);
+
+  useEffect(() => {
+    if (!justSent) return;
+    const t = setTimeout(() => setJustSent(false), SENT_FLASH_MS);
+    return () => clearTimeout(t);
+  }, [justSent]);
+
+  return (
+    <Popover modal open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="Send feedback"
+              disabled={!backendConnected}
+              className={cn(
+                "relative flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
+                "hover:bg-accent hover:text-foreground disabled:opacity-50",
+                "data-[state=open]:bg-accent data-[state=open]:text-foreground",
+              )}
+            >
+              <MessageSquare
+                className={cn(
+                  "absolute size-4 transition-all duration-300",
+                  justSent ? "scale-50 opacity-0" : "scale-100 opacity-100",
+                )}
+              />
+              <Check
+                className={cn(
+                  "absolute size-4 text-success transition-all duration-300",
+                  justSent ? "scale-100 opacity-100" : "scale-50 opacity-0",
+                )}
+              />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Send feedback</TooltipContent>
+      </Tooltip>
+      <PopoverContent side="top" align="end" sideOffset={10} className="w-[30rem] p-5">
+        <FeedbackForm
+          onClose={() => setOpen(false)}
+          onSent={() => {
+            setOpen(false);
+            setJustSent(true);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function FeedbackForm({ onClose, onSent }: { onClose: () => void; onSent: () => void }) {
+  const draft = useFeedbackStore();
+  const view = useUIStore((s) => s.view);
+  const available = trpc.feedback.available.useQuery();
+  const send = trpc.feedback.send.useMutation();
+  const [error, setError] = useState<"email" | "send" | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  // No PostHog client in this build (no key, or dev without OPENTRADE_ANALYTICS_DEV=1):
+  // the form still renders in full, only Send is disabled.
+  const unavailable = available.data?.available === false;
+  const canSend =
+    available.data?.available === true && draft.message.trim() !== "" && !send.isPending;
+
+  const submit = async () => {
+    if (!canSend) return;
+    const email = draft.email.trim() || undefined;
+    if (!FeedbackInput.shape.email.safeParse(email).success) {
+      setError("email");
+      return;
+    }
+    setError(null);
+    try {
+      const result = await send.mutateAsync({
+        submissionId: draft.submissionId,
+        message: draft.message.trim(),
+        email,
+        includeDiagnostics: draft.includeDiagnostics,
+        view,
+      });
+      if (!result.ok) throw new Error("send failed");
+      draft.reset();
+      onSent();
+    } catch {
+      setError("send");
+    }
+  };
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: ⌘↵ shortcut for the form; each field is still individually focusable.
+    <div
+      className="space-y-5"
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+          e.preventDefault();
+          void submit();
+        }
+      }}
+    >
+      <div className="flex items-center justify-between">
+        <p className="text-base font-semibold">Send feedback</p>
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="-mr-1.5 -mt-1.5 flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+
+      <Textarea
+        ref={textareaRef}
+        value={draft.message}
+        onChange={(e) => draft.setMessage(e.target.value)}
+        maxLength={FEEDBACK_MESSAGE_MAX}
+        rows={5}
+        placeholder="Bugs, ideas, feature requests, brokers to support, etc."
+        // Match the Input's lighter placeholder so the two fields read as one style.
+        className="resize-none px-3 py-2.5 leading-relaxed placeholder:text-muted-foreground/60"
+      />
+
+      <div className="space-y-1.5">
+        <Input
+          type="email"
+          value={draft.email}
+          onChange={(e) => draft.setEmail(e.target.value)}
+          placeholder="Email (optional)"
+          autoComplete="email"
+          spellCheck={false}
+          className="py-2"
+        />
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          We'll get back to you within 12 hours.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-sm">Include anonymous app data</span>
+          <SettingToggle
+            checked={draft.includeDiagnostics}
+            onChange={draft.setIncludeDiagnostics}
+          />
+        </div>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Generic app data to help debug issues. Never includes conversations, orders, positions,
+          tickers, account details, or any identifying information.
+        </p>
+      </div>
+
+      {error === "email" && (
+        <p className="text-xs text-destructive">Enter a valid email, or leave it blank.</p>
+      )}
+      {error === "send" && (
+        <p className="text-xs text-destructive">
+          Couldn't send. Try again, or <DiscordLink label="reach us on Discord" />
+        </p>
+      )}
+
+      <div className="flex items-center justify-between gap-3 pt-1">
+        <span className="text-xs text-muted-foreground">
+          {unavailable ? (
+            "Not available in this build."
+          ) : (
+            <DiscordLink label="Join our Discord server" />
+          )}
+        </span>
+        <Button type="button" disabled={!canSend} onClick={() => void submit()}>
+          {send.isPending ? <Loader2 className="size-3.5 animate-spin" /> : null}
+          {send.isPending ? "Sending…" : "Send"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function DiscordLink({ label }: { label: string }) {
+  return (
+    <a
+      href={OPENTRADE_DISCORD_URL}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex items-center gap-1 text-primary hover:underline"
+    >
+      {label}
+      <ExternalLink className="size-3" />
+    </a>
+  );
+}

--- a/app/src/renderer/components/layout/RightPanel.tsx
+++ b/app/src/renderer/components/layout/RightPanel.tsx
@@ -3,6 +3,7 @@ import { trpc } from "../../lib/trpc";
 import { cn } from "../../lib/utils";
 import { useConnectionStore } from "../../stores/connection";
 import { type RightTab, useUIStore } from "../../stores/ui";
+import { FeedbackButton } from "../feedback/FeedbackButton";
 import { Activity } from "../panels/Activity";
 import { MarketClock } from "../panels/MarketClock";
 import { MonitorPanel } from "../panels/Monitor";
@@ -70,8 +71,9 @@ export function RightPanel() {
         </TabsContent>
       </Tabs>
 
-      <div className="flex shrink-0 px-4 py-2">
+      <div className="flex shrink-0 items-center justify-between px-4 py-2">
         <BrokerIndicator />
+        <FeedbackButton />
       </div>
     </div>
   );

--- a/app/src/renderer/components/settings/TelemetryOptOutDialog.tsx
+++ b/app/src/renderer/components/settings/TelemetryOptOutDialog.tsx
@@ -19,7 +19,8 @@ export const OPENTRADE_DISCORD_URL = "https://discord.gg/F63YFPRtq";
  * contiguous group of `TELEMETRY_EVENTS`, and a new event there needs a home here:
  *  1. app — `host_started`, `app_opened`, `app_updated`, `update_downloaded`, the
  *     `onboarding_*` funnel, `setting_changed`, `telemetry_enabled|disabled`,
- *     `notification_clicked`, `broker_connected|broker_connect_failed`.
+ *     `notification_clicked`, `broker_connected|broker_connect_failed`, `feedback_sent`
+ *     (usage only — the feedback message itself is not telemetry, §12.8).
  *  2. agents — `agent_created|archived|restarted`, `terminal_session_started|respawned`,
  *     `schedule_created|fired`, `headless_run_finished`, `agent_marked_broken`,
  *     `turn_limit_reached`, and the categorical `order_gate_prompted|decided` +

--- a/app/src/renderer/stores/feedback.ts
+++ b/app/src/renderer/stores/feedback.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+
+/**
+ * The feedback form's draft. Lives outside the component because the popover unmounts
+ * its content on close — a stray outside click must not throw away a half-written
+ * message. Cleared only on a successful send. Session-only.
+ */
+interface FeedbackDraft {
+  /** Per-draft id, sent along so a retried submission can't be stored twice. */
+  submissionId: string;
+  message: string;
+  email: string;
+  includeDiagnostics: boolean;
+  setMessage: (message: string) => void;
+  setEmail: (email: string) => void;
+  setIncludeDiagnostics: (on: boolean) => void;
+  reset: () => void;
+}
+
+const fresh = () => ({
+  submissionId: crypto.randomUUID(),
+  message: "",
+  email: "",
+  includeDiagnostics: true,
+});
+
+export const useFeedbackStore = create<FeedbackDraft>((set) => ({
+  ...fresh(),
+  setMessage: (message) => set({ message }),
+  setEmail: (email) => set({ email }),
+  setIncludeDiagnostics: (includeDiagnostics) => set({ includeDiagnostics }),
+  reset: () => set(fresh()),
+}));

--- a/app/src/shared/analytics.ts
+++ b/app/src/shared/analytics.ts
@@ -230,6 +230,10 @@ export const TELEMETRY_EVENTS = {
   // notifications
   notification_clicked: z.strictObject({ kind: NotificationKind }),
 
+  // in-app feedback usage (§12.8); the message itself is the separate, ungated
+  // `feedback_submitted` event, never this allowlist
+  feedback_sent: z.strictObject({ with_email: z.boolean(), with_diagnostics: z.boolean() }),
+
   // errors (sanitized)
   app_error: z.strictObject({
     subsystem: ErrorSubsystem,

--- a/app/src/shared/feedback.test.ts
+++ b/app/src/shared/feedback.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { FeedbackDiagnostics, FeedbackInput } from "./feedback";
+
+// Zod's own behaviour isn't under test here — only the two guarantees the privacy
+// boundary rests on: both schemas are strict, and a blank email must be absent, not "".
+describe("feedback schemas", () => {
+  const input = {
+    submissionId: "3f1c2b6e-8c1a-4a4b-9d0e-1a2b3c4d5e6f",
+    message: "hi",
+    includeDiagnostics: false,
+    view: "agents",
+  };
+
+  test("FeedbackInput rejects an extra field and a blank-string email", () => {
+    expect(FeedbackInput.safeParse(input).success).toBe(true);
+    expect(FeedbackInput.safeParse({ ...input, ticker: "AAPL" }).success).toBe(false);
+    expect(FeedbackInput.safeParse({ ...input, email: "" }).success).toBe(false);
+  });
+
+  test("FeedbackDiagnostics rejects an extra field and a path-shaped version", () => {
+    const result = FeedbackDiagnostics.safeParse({ home: "/Users/someone" });
+    expect(result.success).toBe(false);
+    expect(FeedbackDiagnostics.shape.claude_version.safeParse("/usr/local/bin").success).toBe(
+      false,
+    );
+    expect(FeedbackDiagnostics.shape.claude_version.safeParse("2.0.1 (Claude Code)").success).toBe(
+      true,
+    );
+  });
+});

--- a/app/src/shared/feedback.ts
+++ b/app/src/shared/feedback.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import { ApprovalMode } from "./agent";
+import { BrokerConnectionStatus } from "./broker";
+
+/**
+ * The in-app feedback form's contract (§12.8). Feedback is a user-initiated message,
+ * kept separate from telemetry: free text plus an optional email, its own strict
+ * schema (the telemetry allowlist forbids free text), not gated by the telemetry
+ * opt-out, sent under the install's anonymous id.
+ */
+
+export const FEEDBACK_MESSAGE_MAX = 2000;
+
+export const FeedbackView = z.enum(["agents", "scheduled", "settings"]);
+export type FeedbackView = z.infer<typeof FeedbackView>;
+
+export const FeedbackInput = z.strictObject({
+  /** Stable per-draft id, sent as the PostHog event uuid so a retry after a timed-out
+   *  flush can't land the same message twice. */
+  submissionId: z.uuid(),
+  message: z.string().trim().min(1).max(FEEDBACK_MESSAGE_MAX),
+  /** Absent (not "") when blank. */
+  email: z.email().max(254).optional(),
+  includeDiagnostics: z.boolean(),
+  view: FeedbackView,
+});
+export type FeedbackInput = z.infer<typeof FeedbackInput>;
+
+/** A CLI `--version` line (e.g. `2.0.1 (Claude Code)`); null when not installed. */
+const cliVersion = z
+  .string()
+  .regex(/^[\w.\-+ ()]{1,64}$/)
+  .nullable();
+const runtimeVersion = z.string().regex(/^[\w.\-+]{1,32}$/);
+const count = z.number().int().nonnegative();
+
+/**
+ * The "Include anonymous app data" block: counts, enums, versions, and the app's own
+ * tunables. Never agent names/ids, tickers, orders, positions, account data, or paths.
+ * Flat on purpose — one key is one column in the PostHog feedback table.
+ */
+export const FeedbackDiagnostics = z.strictObject({
+  // build + runtime
+  app_version: z.string().max(64),
+  platform: z.string().max(32),
+  arch: z.string().max(32),
+  os_release: z.string().regex(/^[\w.\-+]{1,64}$/),
+  electron_version: runtimeVersion.nullable(),
+  node_version: runtimeVersion,
+  claude_version: cliVersion,
+  codex_version: cliVersion,
+  host_uptime_sec: count,
+
+  // agents — counts only
+  agent_count: count,
+  agents_claude: count,
+  agents_codex: count,
+  agents_working: count,
+  agents_needs_input: count,
+  agents_awaiting_approval: count,
+  /** Marked unresumable by the wake layer (§12.2). */
+  agents_broken: count,
+  agents_auto_mode: count,
+  /** Turn limit on and the headless budget spent. */
+  agents_turn_limited: count,
+  agents_active_24h: count,
+  schedules_enabled: count,
+  monitors_enabled: count,
+
+  // broker — status only
+  broker_status: BrokerConnectionStatus,
+  broker_authorized: z.boolean(),
+  /** Age of the cached portfolio snapshot; null before the first fetch. */
+  broker_portfolio_age_sec: count.nullable(),
+  pending_approvals: count,
+
+  // settings that can explain behaviour
+  telemetry_enabled: z.boolean(),
+  default_approval_mode: ApprovalMode,
+  approval_timeout_sec: count,
+  poll_interval_focused_sec: count,
+  poll_interval_blurred_sec: count,
+  headless_turn_limit_enabled: z.boolean(),
+  max_headless_turns: count,
+  max_headless_run_minutes: count,
+  background_allow_api_key: z.boolean(),
+});
+export type FeedbackDiagnostics = z.infer<typeof FeedbackDiagnostics>;


### PR DESCRIPTION
## Summary

A message icon at the right end of the right panel's footer (beside the broker connection indicator) opens a popover with a message field, an optional reply email, an "Include anonymous app data" toggle, and Send (⌘↵ also submits). On success the popover closes and the icon briefly shows a green check; on failure the error shows inline with a Discord link. The draft persists across closing the popover until a send succeeds. A build without a PostHog key renders the same form with Send disabled.

## How it works

- Submissions go out through the backend host's existing PostHog client as one `feedback_submitted` event under the install's anonymous id. Each draft carries a uuid that becomes the event's uuid, so a retry after a timed-out flush is deduplicated instead of stored twice.
- This is a separate path from telemetry: its own strict schema (`shared/feedback.ts`) rather than the categorical-only `TELEMETRY_EVENTS` allowlist, not gated by the telemetry opt-out (clicking Send is the consent), and it awaits the flush so the UI reports a real sent/failed outcome. Nothing is set on the person profile; the email lives on the event only.
- The app-data block is built host-side (`buildDiagnostics`, a pure function over plain values) from a strict, flat schema of counts, enums, and version strings: app/OS/Electron/Node/CLI versions; agent counts by harness, status, execution state, approval mode, and turn budget; enabled schedule and monitor counts; broker status, authorization, and cached-portfolio age; pending approvals; and the settings that can explain behaviour. The renderer contributes only which view was open.
- A categorical `feedback_sent` telemetry event records usage through the normal allowlist and gate.

## Tests

- `shared/feedback.test.ts`: both schemas are strict; a blank email must be absent, not `""`.
- `services/feedback/diagnostics.test.ts`: the builder's counts and ages, and the CLI version normalizer.
- `services/analytics/analytics.test.ts`: `sendFeedback` sends under the install id even when telemetry is off, uses the draft uuid, emits no profile properties, drops an out-of-schema diagnostics block but still sends the message, and reports flush failures.

Full gate: `bun test app/src` (385 pass), typecheck, production build, biome.