### PR TITLE
Give the macOS DMG a version-less asset name

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ Agents continue to get notified and work in the background, even if the app is c
 
 ## Install
 
-Download the latest `OpenTrade-<version>-arm64.dmg` from
-[Releases](https://github.com/OpenTradeOSS/OpenTrade/releases), open it, and drag OpenTrade to
+Download [OpenTrade-arm64.dmg](https://github.com/OpenTradeOSS/OpenTrade/releases/latest/download/OpenTrade-arm64.dmg)
+— that link always resolves to the newest release; older builds are on the
+[Releases](https://github.com/OpenTradeOSS/OpenTrade/releases) page. Open it and drag OpenTrade to
 Applications. Requires an Apple Silicon Mac. The app auto-updates from GitHub Releases.
 
 OpenTrade supports both Claude Code and Codex agents, so please install and sign into `claude`

--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -49,6 +49,12 @@ mac:
   # CSC_LINK / CSC_KEY_PASSWORD. See docs/PACKAGING.md.
   notarize: true
 dmg:
+  # Deliberately version-less so the download filename is stable across releases and
+  # GitHub's `/releases/latest/download/<name>` permalink always resolves — the website's
+  # download button points at it and must not need a bump every release. `${arch}` keeps
+  # the name honest if an x64/universal build is added later. The mounted volume still
+  # shows the version via `title` below.
+  artifactName: ${productName}-${arch}.${ext}
   title: OpenTrade ${version}
   contents:
     - x: 130

--- a/website/src/components/templates/creative-studio/hero.tsx
+++ b/website/src/components/templates/creative-studio/hero.tsx
@@ -10,12 +10,11 @@ import { CinematicBackground, NoiseOverlay } from "./primitives";
 
 const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
 
-// Pinned to a specific release because the asset filename embeds the version, so GitHub's
-// `/releases/latest/download/<name>` permalink would 404 on the next release. Bump this on
-// every release until the DMG gets a version-less `artifactName` in electron-builder.yml,
-// after which the permalink can be used directly. Apple silicon only — no x64 build ships.
+// Version-less permalink: the DMG ships under a fixed `artifactName` (see
+// app/electron-builder.yml), so GitHub resolves this to the newest release's installer and
+// the link never needs bumping. Apple silicon only — no x64 build ships.
 const DOWNLOAD_URL =
-  "https://github.com/OpenTradeOSS/OpenTrade/releases/download/v0.2.6/OpenTrade-0.2.6-arm64.dmg";
+  "https://github.com/OpenTradeOSS/OpenTrade/releases/latest/download/OpenTrade-arm64.dmg";
 
 function GitHubMark({ className }: { className?: string }) {
   return (


### PR DESCRIPTION
electron-builder's default `artifactName` embeds the version, so the installer was published as `OpenTrade-<version>-arm64.dmg` and every consumer of that filename had to be updated on each release. This pins `dmg.artifactName` to `${productName}-${arch}.${ext}`, so the asset is always `OpenTrade-arm64.dmg` and GitHub's `/releases/latest/download/OpenTrade-arm64.dmg` permalink resolves to the newest build. The website download button and the README install link now use that permalink.

The zip keeps its versioned name: `latest-mac.yml` lists that exact filename and electron-updater fetches it, so renaming it would buy nothing and risk the update path.

Verified against a local unsigned build:
- artifacts come out as `OpenTrade-arm64.dmg` + `OpenTrade-<version>-arm64-mac.zip`
- `latest-mac.yml`'s `path`/`sha512` still point at the versioned zip (auto-update unchanged)
- the mounted volume still shows the version via `dmg.title`

Note: the permalink starts resolving with the first release built after this merges (v0.2.7); existing releases keep their versioned DMG names.
