### PR TITLE
Release v0.2.7

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentrade/app",
   "productName": "OpenTrade",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "OpenTrade — a transparent control panel for local Claude Code / Codex trading agents.",
   "author": "OpenTrade contributors",
   "homepage": "https://github.com/OpenTradeOSS/OpenTrade",


### PR DESCRIPTION
Bumps `app/package.json` to 0.2.7. The `v0.2.7` tag points at this commit; CI is building the release from it. First release carrying the static `OpenTrade-arm64.dmg` asset name (#24), which makes the `/releases/latest/download/OpenTrade-arm64.dmg` permalink live once published.