### PR TITLE
Pin each cron schedule to the timezone it was created in

### DIFF
--- a/app/src/main/db/ddl.ts
+++ b/app/src/main/db/ddl.ts
@@ -61,6 +61,7 @@ export const SCHEMA_DDL = `
       id TEXT PRIMARY KEY,
       agent_id TEXT NOT NULL,
       cron_expr TEXT NOT NULL,
+      timezone TEXT,
       prompt TEXT NOT NULL,
       recurring INTEGER NOT NULL DEFAULT 1,
       enabled INTEGER NOT NULL DEFAULT 1,

--- a/app/src/main/db/migrate.test.ts
+++ b/app/src/main/db/migrate.test.ts
@@ -37,6 +37,7 @@ describe("db migrations", () => {
     expect(columns(db, "agents")).toContain("harness");
     expect(columns(db, "wakes")).toContain("source_id"); // v4
     expect(columns(db, "agents")).toContain("last_turn_at"); // v5
+    expect(columns(db, "schedules")).toContain("timezone"); // v6
     // Whole new tables ride the DDL — no migration, no version bump (§6.3).
     expect(columns(db, "recent_notifications")).toContain("at");
   });
@@ -110,6 +111,34 @@ describe("db migrations", () => {
     const row = db.query("SELECT * FROM wakes WHERE id = 'w1'").get() as Record<string, unknown>;
     expect(row.prompt).toBe("run"); // data survived
     expect(row.source_id).toBeNull(); // pre-v4 rows read NULL, not a bogus id
+  });
+
+  test("v6 adds schedules.timezone to an existing (v5) DB, preserving rows as NULL", () => {
+    const db = new Database(":memory:");
+    const m = wrap(db);
+    // A pre-v6 schedules table (no timezone) with a live cron in it, stamped at v5.
+    db.exec(`CREATE TABLE schedules (
+      id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, cron_expr TEXT NOT NULL,
+      prompt TEXT NOT NULL, recurring INTEGER NOT NULL DEFAULT 1,
+      enabled INTEGER NOT NULL DEFAULT 1, next_fire_at INTEGER,
+      last_fired_at INTEGER, created_at INTEGER NOT NULL
+    );`);
+    db.exec(
+      `INSERT INTO schedules (id, agent_id, cron_expr, prompt, recurring, enabled, created_at)
+       VALUES ('s1', 'a1', '30 5 * * 1-5', 'premarket', 1, 1, 1000)`,
+    );
+    db.exec("PRAGMA user_version = 5");
+    db.exec(SCHEMA_DDL);
+    migrate(m, { fresh: false });
+
+    expect(userVersion(m)).toBe(SCHEMA_VERSION);
+    expect(columns(db, "schedules")).toContain("timezone");
+    const row = db.query("SELECT * FROM schedules WHERE id = 's1'").get() as Record<
+      string,
+      unknown
+    >;
+    expect(row.cron_expr).toBe("30 5 * * 1-5"); // data survived
+    expect(row.timezone).toBeNull(); // the scheduler backfills this at its next boot
   });
 
   test("refuses to open a DB stamped newer than this build (downgrade guard)", () => {

--- a/app/src/main/db/migrate.ts
+++ b/app/src/main/db/migrate.ts
@@ -34,7 +34,7 @@ export interface MigrationDb {
 }
 
 /** Bump on every schema change, with a matching entry in MIGRATIONS. */
-export const SCHEMA_VERSION = 5;
+export const SCHEMA_VERSION = 6;
 
 const MIGRATIONS: Record<number, (db: MigrationDb) => void> = {
   // v2 — headless turn limit: per-agent unattended-turn counter + on/off toggle.
@@ -57,6 +57,11 @@ const MIGRATIONS: Record<number, (db: MigrationDb) => void> = {
   // back to their wake/audit history in the meantime.
   5: (db) => {
     addColumnIfMissing(db, "agents", "last_turn_at", "INTEGER");
+  },
+  // v6 — the IANA timezone each cron expression is evaluated in (§12.2). Nullable:
+  // pre-v6 rows read NULL until the scheduler backfills them on its next boot.
+  6: (db) => {
+    addColumnIfMissing(db, "schedules", "timezone", "TEXT");
   },
 };
 

--- a/app/src/main/db/schema.ts
+++ b/app/src/main/db/schema.ts
@@ -68,7 +68,9 @@ export const settings = sqliteTable("settings", {
 /**
  * Durable cron schedules owned by the backend (survive app close / host restart,
  * unlike Claude Code's session-scoped CronCreate). `next_fire_at` is advisory —
- * the scheduler recomputes it from `cron_expr` on boot rather than trusting it.
+ * the scheduler recomputes it from `cron_expr` (in `timezone`) on boot rather than
+ * trusting it. `timezone` (v6) is the machine's IANA zone when the row was created;
+ * NULL only on pre-v6 rows until the scheduler backfills them at boot.
  */
 export const schedules = sqliteTable(
   "schedules",
@@ -76,6 +78,7 @@ export const schedules = sqliteTable(
     id: text("id").primaryKey(),
     agentId: text("agent_id").notNull(),
     cronExpr: text("cron_expr").notNull(),
+    timezone: text("timezone"),
     prompt: text("prompt").notNull(),
     recurring: integer("recurring", { mode: "boolean" }).notNull().default(true),
     enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),

--- a/app/src/main/services/local-api/index.ts
+++ b/app/src/main/services/local-api/index.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { PreToolUseDecision } from "@shared/approval";
-import { CronCreateInput, MonitorCreateInput } from "@shared/schedule";
+import { CronCreateInput, MonitorCreateInput, type Schedule } from "@shared/schedule";
 import type { AgentRegistry } from "../agents/registry";
 import type { ApprovalService } from "../approvals";
 import type { BrokerService } from "../broker";
@@ -293,13 +293,13 @@ export class LocalApiServer {
     try {
       if (req.method === "GET" && path === "/schedules") {
         return json(res, 200, {
-          cron: scheduler.listCron(agentId),
+          cron: scheduler.listCron(agentId).map(agentFacingSchedule),
           monitors: scheduler.listMonitors(agentId),
         });
       }
       if (req.method === "POST" && path === "/schedules/cron") {
         const input = CronCreateInput.parse(await readJson(req));
-        return json(res, 200, scheduler.createCron(agentId, input));
+        return json(res, 200, agentFacingSchedule(scheduler.createCron(agentId, input)));
       }
       if (req.method === "POST" && path === "/schedules/monitor") {
         const input = MonitorCreateInput.parse(await readJson(req));
@@ -332,6 +332,12 @@ function deny(reason: string): PreToolUseDecision {
       permissionDecisionReason: reason,
     },
   };
+}
+
+/** The agent's view of a schedule: everything but the host-owned `timezone` (§12.2). */
+function agentFacingSchedule(schedule: Schedule): Omit<Schedule, "timezone"> {
+  const { timezone: _timezone, ...rest } = schedule;
+  return rest;
 }
 
 function header(req: IncomingMessage, name: string): string | null {

--- a/app/src/main/services/local-api/schedules-route.test.ts
+++ b/app/src/main/services/local-api/schedules-route.test.ts
@@ -11,9 +11,10 @@ const scheduler = {
   createCron: (_a: string, input: { cron: string; prompt: string }) => ({
     id: "s1",
     cronExpr: input.cron,
+    timezone: "America/New_York", // host-owned; must never reach the agent
     prompt: input.prompt,
   }),
-  listCron: () => [{ id: "s1" }],
+  listCron: () => [{ id: "s1", timezone: "America/New_York" }],
   listMonitors: () => [],
   deleteCron: () => true,
   createMonitor: (_a: string, input: { command: string }) => ({ id: "m1", command: input.command }),
@@ -58,9 +59,10 @@ describe("/schedules routes", () => {
       body: JSON.stringify({ cron: "0 9 * * *", prompt: "review", recurring: true }),
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { id: string; cronExpr: string };
+    const body = (await res.json()) as Record<string, unknown>;
     expect(body.id).toBe("s1");
     expect(body.cronExpr).toBe("0 9 * * *");
+    expect(body).not.toHaveProperty("timezone"); // host-owned, hidden from the agent
   });
 
   test("rejects a malformed cron body (zod)", async () => {
@@ -75,8 +77,9 @@ describe("/schedules routes", () => {
   test("lists cron + monitors", async () => {
     const res = await fetch(`${base}/schedules`, { headers: hdrs });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { cron: unknown[]; monitors: unknown[] };
+    const body = (await res.json()) as { cron: Record<string, unknown>[]; monitors: unknown[] };
     expect(body.cron).toHaveLength(1);
+    expect(body.cron[0]).not.toHaveProperty("timezone"); // hidden from the agent's CronList
     expect(body.monitors).toEqual([]);
   });
 

--- a/app/src/main/services/scheduler/cron-timer.test.ts
+++ b/app/src/main/services/scheduler/cron-timer.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { CronTimer } from "./cron-timer";
 
+const TZ = "America/New_York";
+
 describe("CronTimer", () => {
   test("isValid accepts 5-field expressions and rejects junk", () => {
     expect(CronTimer.isValid("30 9 * * 1-5")).toBe(true);
@@ -11,7 +13,7 @@ describe("CronTimer", () => {
 
   test("arm returns a future next-fire time and nextRun matches", () => {
     const t = new CronTimer();
-    const next = t.arm("a", "*/5 * * * *", true, () => {});
+    const next = t.arm("a", "*/5 * * * *", TZ, true, () => {});
     expect(next).not.toBeNull();
     expect(next!).toBeGreaterThan(Date.now());
     expect(t.nextRun("a")).toBe(next);
@@ -20,7 +22,7 @@ describe("CronTimer", () => {
 
   test("disarm stops a job and forgets its next run", () => {
     const t = new CronTimer();
-    t.arm("b", "0 0 * * *", true, () => {});
+    t.arm("b", "0 0 * * *", TZ, true, () => {});
     expect(t.nextRun("b")).not.toBeNull();
     t.disarm("b");
     expect(t.nextRun("b")).toBeNull();
@@ -28,10 +30,19 @@ describe("CronTimer", () => {
 
   test("re-arming the same id replaces the prior timer", () => {
     const t = new CronTimer();
-    const first = t.arm("c", "0 9 * * *", true, () => {});
-    const second = t.arm("c", "0 17 * * *", true, () => {});
+    const first = t.arm("c", "0 9 * * *", TZ, true, () => {});
+    const second = t.arm("c", "0 17 * * *", TZ, true, () => {});
     expect(second).not.toBe(first);
     expect(t.nextRun("c")).toBe(second);
+    t.disarmAll();
+  });
+
+  test("the expression is evaluated in the given zone, not the process's local zone", () => {
+    const t = new CronTimer();
+    // 5:30 in Dubai (no DST) is always 01:30 UTC, whatever zone the test runs in.
+    const next = new Date(t.arm("d", "30 5 * * *", "Asia/Dubai", true, () => {}) ?? 0);
+    expect(next.getUTCHours()).toBe(1);
+    expect(next.getUTCMinutes()).toBe(30);
     t.disarmAll();
   });
 });

--- a/app/src/main/services/scheduler/cron-timer.ts
+++ b/app/src/main/services/scheduler/cron-timer.ts
@@ -2,20 +2,26 @@ import { Cron } from "croner";
 
 /**
  * Thin wrapper over `croner` holding one live timer per schedule id. 5-field cron
- * expressions in the machine's local timezone (croner's default), so DST shifts
- * are handled by the library. Recurring schedules run forever; one-shot schedules
- * use `maxRuns: 1` and croner auto-stops them after the single occurrence.
+ * expressions, each evaluated in the IANA timezone passed to `arm` (so DST shifts in
+ * that zone are handled by the library). Recurring schedules run forever; one-shot
+ * schedules use `maxRuns: 1` and croner auto-stops them after the single occurrence.
  */
 export class CronTimer {
   private jobs = new Map<string, Cron>();
 
   /**
-   * Arm (or re-arm) a schedule. `onFire` runs on each occurrence. Returns the next
-   * fire time in epoch-ms, or null if the expression never fires again.
+   * Arm (or re-arm) a schedule in `timezone`. `onFire` runs on each occurrence.
+   * Returns the next fire time in epoch-ms, or null if the expression never fires again.
    */
-  arm(id: string, cronExpr: string, recurring: boolean, onFire: () => void): number | null {
+  arm(
+    id: string,
+    cronExpr: string,
+    timezone: string,
+    recurring: boolean,
+    onFire: () => void,
+  ): number | null {
     this.disarm(id);
-    const job = new Cron(cronExpr, recurring ? {} : { maxRuns: 1 }, onFire);
+    const job = new Cron(cronExpr, recurring ? { timezone } : { timezone, maxRuns: 1 }, onFire);
     this.jobs.set(id, job);
     return job.nextRun()?.getTime() ?? null;
   }

--- a/app/src/main/services/scheduler/index.ts
+++ b/app/src/main/services/scheduler/index.ts
@@ -6,7 +6,7 @@ import type {
   Schedule,
   Wake,
 } from "@shared/schedule";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { Db } from "../../db/client";
 import {
@@ -22,6 +22,7 @@ import type { LocalApiServer } from "../local-api";
 import { buildAgentEnv } from "../terminal/env";
 import { CronTimer } from "./cron-timer";
 import { MonitorRunner } from "./monitor-runner";
+import { systemTimeZone } from "./system-timezone";
 import type { WakeTransport } from "./wake/types";
 
 /**
@@ -45,6 +46,14 @@ export class Scheduler {
 
   /** Load enabled rows and arm their timers / monitor children. */
   start(): void {
+    // Backfill pre-v6 rows with the machine's current zone: until the column existed they
+    // were evaluated in the process's local zone, so this pins the behaviour they had.
+    const bootZone = systemTimeZone();
+    this.db
+      .update(schedulesTable)
+      .set({ timezone: bootZone })
+      .where(isNull(schedulesTable.timezone))
+      .run();
     for (const row of this.db.select().from(schedulesTable).all()) {
       if (!row.enabled) continue;
       // Self-heal a genuinely-orphaned row (agent no longer exists at all) by hard-deleting
@@ -76,7 +85,7 @@ export class Scheduler {
           continue;
         }
       }
-      this.armCron(row.id, row.agentId, row.cronExpr, row.prompt, row.recurring);
+      this.armRow(row);
     }
 
     for (const row of this.db.select().from(monitorsTable).all()) {
@@ -88,7 +97,9 @@ export class Scheduler {
       if (this.registry.executionStateOf(row.agentId) === "broken") continue; // paused (see above)
       this.startMonitor(row.id, row.agentId, row.command);
     }
-    hostLog.info(`scheduler started: ${this.runners.size} monitor(s), crons armed`);
+    hostLog.info(
+      `scheduler started: ${this.runners.size} monitor(s), crons armed (machine tz ${bootZone})`,
+    );
   }
 
   /**
@@ -139,7 +150,7 @@ export class Scheduler {
       .where(eq(schedulesTable.agentId, agentId))
       .all()) {
       if (!row.enabled) continue;
-      this.armCron(row.id, row.agentId, row.cronExpr, row.prompt, row.recurring);
+      this.armRow(row);
     }
     for (const row of this.db
       .select()
@@ -227,12 +238,15 @@ export class Scheduler {
     }
     const id = nanoid();
     const now = Date.now();
+    // Pin the machine's zone the agent authored this in; the agent never names one (§12.2).
+    const timezone = systemTimeZone();
     this.db
       .insert(schedulesTable)
       .values({
         id,
         agentId,
         cronExpr: input.cron,
+        timezone,
         prompt: input.prompt,
         recurring: input.recurring,
         enabled: true,
@@ -241,7 +255,7 @@ export class Scheduler {
         createdAt: now,
       })
       .run();
-    this.armCron(id, agentId, input.cron, input.prompt, input.recurring);
+    this.armCron(id, agentId, input.cron, timezone, input.prompt, input.recurring);
     bus.emitEvent("scheduler:changed", { agentId });
     analytics.track("schedule_created", { kind: "cron", recurring: input.recurring });
     return this.getCron(id)!;
@@ -340,14 +354,21 @@ export class Scheduler {
 
   // ---- internals ----
 
+  /** Arm a stored row in its pinned zone (the fallback only covers a not-yet-backfilled row). */
+  private armRow(row: typeof schedulesTable.$inferSelect): void {
+    const zone = row.timezone ?? systemTimeZone();
+    this.armCron(row.id, row.agentId, row.cronExpr, zone, row.prompt, row.recurring);
+  }
+
   private armCron(
     id: string,
     agentId: string,
     cronExpr: string,
+    timezone: string,
     prompt: string,
     recurring: boolean,
   ): void {
-    const next = this.cron.arm(id, cronExpr, recurring, () => {
+    const next = this.cron.arm(id, cronExpr, timezone, recurring, () => {
       const fired = this.fireTracked(agentId, prompt, "cron", id);
       if (fired) this.markCronFired(id);
       if (recurring) {
@@ -513,6 +534,7 @@ function rowToSchedule(row: typeof schedulesTable.$inferSelect): Schedule {
     id: row.id,
     agentId: row.agentId,
     cronExpr: row.cronExpr,
+    timezone: row.timezone,
     prompt: row.prompt,
     recurring: row.recurring,
     enabled: row.enabled,

--- a/app/src/main/services/scheduler/scheduler.test.ts
+++ b/app/src/main/services/scheduler/scheduler.test.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 import { tmpdir } from "node:os";
 import type { Agent } from "@shared/agent";
+import { Cron } from "croner";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import type { Db } from "../../db/client";
 import * as schema from "../../db/schema";
@@ -16,7 +17,7 @@ function memDb(): Db {
   sqlite.exec(`
     CREATE TABLE schedules (
       id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, cron_expr TEXT NOT NULL,
-      prompt TEXT NOT NULL, recurring INTEGER NOT NULL DEFAULT 1,
+      timezone TEXT, prompt TEXT NOT NULL, recurring INTEGER NOT NULL DEFAULT 1,
       enabled INTEGER NOT NULL DEFAULT 1, next_fire_at INTEGER,
       last_fired_at INTEGER, created_at INTEGER NOT NULL);
     CREATE TABLE monitors (
@@ -392,5 +393,86 @@ describe("Scheduler CRUD", () => {
     expect(wakes.length).toBeGreaterThanOrEqual(1);
     expect(wakes[0].sourceKind).toBe("monitor");
     expect(wakes[0].sourceId).toBe(m.id); // links wake → its monitor
+  });
+});
+
+describe("Scheduler cron timezone pinning", () => {
+  let scheduler: Scheduler;
+  afterEach(() => scheduler?.stop());
+
+  const savedTz = process.env.TZ;
+  afterEach(() => {
+    if (savedTz === undefined) delete process.env.TZ;
+    else process.env.TZ = savedTz;
+  });
+
+  const nextIn = (expr: string, timezone: string) =>
+    new Cron(expr, { timezone, paused: true }).nextRun()?.getTime();
+
+  test("createCron stamps the machine's zone at creation and arms in it", () => {
+    process.env.TZ = "Asia/Dubai"; // what `systemTimeZone()` resolves in this process
+    scheduler = makeScheduler();
+    const created = scheduler.createCron("agent1", {
+      cron: "30 5 * * *",
+      prompt: "premarket",
+      recurring: true,
+    });
+    expect(created.timezone).toBe("Asia/Dubai");
+    expect(created.nextFireAt).toBe(nextIn("30 5 * * *", "Asia/Dubai"));
+  });
+
+  test("a stored zone is honoured on boot even when the machine has since moved", () => {
+    const db = memDb();
+    db.insert(schema.schedules)
+      .values({
+        id: "pinned",
+        agentId: "agent1",
+        cronExpr: "30 5 * * *",
+        timezone: "America/Los_Angeles", // authored in LA…
+        prompt: "premarket",
+        recurring: true,
+        enabled: true,
+        nextFireAt: null,
+        lastFiredAt: null,
+        createdAt: 1,
+      })
+      .run();
+    process.env.TZ = "Asia/Dubai"; // …but the host now boots in Dubai
+    scheduler = makeSchedulerOn(db);
+    scheduler.start();
+    const [row] = scheduler.listCron("agent1");
+    expect(row.timezone).toBe("America/Los_Angeles"); // unchanged by the move
+    expect(row.nextFireAt).toBe(nextIn("30 5 * * *", "America/Los_Angeles"));
+    expect(row.nextFireAt).not.toBe(nextIn("30 5 * * *", "Asia/Dubai"));
+  });
+
+  test("start() backfills a pre-v6 row (NULL zone) with the machine's current zone", () => {
+    const db = memDb();
+    for (const [id, enabled] of [
+      ["live", true],
+      ["retired", false],
+    ] as const) {
+      db.insert(schema.schedules)
+        .values({
+          id,
+          agentId: "agent1",
+          cronExpr: "0 9 * * *",
+          timezone: null,
+          prompt: "p",
+          recurring: true,
+          enabled,
+          nextFireAt: null,
+          lastFiredAt: null,
+          createdAt: 1,
+        })
+        .run();
+    }
+    process.env.TZ = "Asia/Tokyo";
+    scheduler = makeSchedulerOn(db);
+    scheduler.start();
+    const rows = db.select().from(schema.schedules).all();
+    expect(rows.map((r) => r.timezone)).toEqual(["Asia/Tokyo", "Asia/Tokyo"]); // both stamped
+    const live = scheduler.listCron("agent1")[0];
+    expect(live.nextFireAt).toBe(nextIn("0 9 * * *", "Asia/Tokyo")); // armed in the stamp
   });
 });

--- a/app/src/main/services/scheduler/system-timezone.test.ts
+++ b/app/src/main/services/scheduler/system-timezone.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { systemTimeZone } from "./system-timezone";
+
+const savedTz = process.env.TZ;
+afterEach(() => {
+  if (savedTz === undefined) delete process.env.TZ;
+  else process.env.TZ = savedTz;
+});
+
+const resolvable = (tz: string) => {
+  new Intl.DateTimeFormat("en-US", { timeZone: tz });
+};
+
+describe("systemTimeZone", () => {
+  test("always returns a zone Intl can resolve", () => {
+    const tz = systemTimeZone();
+    expect(tz.length).toBeGreaterThan(0);
+    expect(() => resolvable(tz)).not.toThrow();
+  });
+
+  test("an explicit, valid TZ env var wins", () => {
+    process.env.TZ = "Asia/Tokyo";
+    expect(systemTimeZone()).toBe("Asia/Tokyo");
+  });
+
+  test("an unparseable TZ env var is ignored in favour of the OS / process zone", () => {
+    process.env.TZ = "Not/AZone";
+    const tz = systemTimeZone();
+    expect(tz).not.toBe("Not/AZone");
+    expect(() => resolvable(tz)).not.toThrow();
+  });
+});

--- a/app/src/main/services/scheduler/system-timezone.ts
+++ b/app/src/main/services/scheduler/system-timezone.ts
@@ -1,0 +1,37 @@
+import { readlinkSync } from "node:fs";
+
+/**
+ * The machine's CURRENT IANA timezone (e.g. `America/New_York`), read from the OS on
+ * every call. Node resolves the process's local zone once at startup and never
+ * refreshes it, so a long-lived host goes stale after a system timezone change while
+ * every fresh shell (the agent's `date`) already sees the new zone; the
+ * `/etc/localtime` symlink (`…/zoneinfo/<Area>/<City>`) does not go stale. An explicit
+ * `TZ` env var wins, since that is what the process itself honours.
+ */
+export function systemTimeZone(): string {
+  return (
+    [process.env.TZ, zoneFromLocaltimeLink()].find(isValidTimeZone) ??
+    Intl.DateTimeFormat().resolvedOptions().timeZone
+  );
+}
+
+function isValidTimeZone(tz: string | undefined): tz is string {
+  if (!tz) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** `/etc/localtime -> /var/db/timezone/zoneinfo/Asia/Dubai` → `Asia/Dubai`. */
+function zoneFromLocaltimeLink(): string | undefined {
+  try {
+    const target = readlinkSync("/etc/localtime");
+    const idx = target.lastIndexOf("zoneinfo/");
+    return idx === -1 ? undefined : target.slice(idx + "zoneinfo/".length);
+  } catch {
+    return undefined;
+  }
+}

--- a/app/src/renderer/components/panels/Monitor.tsx
+++ b/app/src/renderer/components/panels/Monitor.tsx
@@ -2,7 +2,7 @@ import type { Monitor, Schedule, Wake } from "@shared/schedule";
 import { ChevronRight, Clock, type LucideIcon, Radio } from "lucide-react";
 import { useState } from "react";
 import { useMonitor } from "../../hooks/useSchedules";
-import { ago, dateTime, describeCron, until } from "../../lib/format";
+import { ago, cronZone, dateTime, describeCron, until } from "../../lib/format";
 import { cn } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui";
 import { AutonomyHint } from "../schedule/AutonomyInfo";
@@ -169,6 +169,7 @@ function UpcomingMonitorRow({ monitor }: { monitor: Monitor }) {
 
 /** Expanded cron detail, mirroring the Scheduled pane: prompt + a schedule/run grid. */
 function CronDetail({ schedule }: { schedule: Schedule }) {
+  const zone = cronZone(schedule.timezone);
   return (
     <div className="space-y-3">
       <Field label="Prompt">
@@ -183,6 +184,7 @@ function CronDetail({ schedule }: { schedule: Schedule }) {
             </code>,
             describeCron(schedule.cronExpr),
           ],
+          ["Timezone", zone.value, zone.hint],
           ["Next run", dateTime(schedule.nextFireAt), null],
           ["Last run", dateTime(schedule.lastFiredAt), null],
           ["Created", dateTime(schedule.createdAt), null],

--- a/app/src/renderer/lib/format.ts
+++ b/app/src/renderer/lib/format.ts
@@ -110,6 +110,13 @@ export function describeCron(expr: string): string {
   return "Custom";
 }
 
+/** The zone a cron is pinned to, plus a hint when this machine is now in a different one. */
+export function cronZone(timezone: string | null): { value: string; hint: string | null } {
+  if (!timezone) return { value: "—", hint: null };
+  const here = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return { value: timezone, hint: here !== timezone ? `this machine is in ${here}` : null };
+}
+
 /** Absolute local date + time, e.g. "Jun 24, 9:00 AM". */
 export function dateTime(ts: number | null | undefined): string {
   if (!ts) return "—";

--- a/app/src/renderer/screens/Scheduled.tsx
+++ b/app/src/renderer/screens/Scheduled.tsx
@@ -6,7 +6,7 @@ import { AutonomyInfoButton } from "../components/schedule/AutonomyInfo";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../components/ui/tooltip";
 import { useAgents } from "../hooks/useAgents";
 import { useSchedules } from "../hooks/useSchedules";
-import { ago, dateTime, describeCron, until } from "../lib/format";
+import { ago, cronZone, dateTime, describeCron, until } from "../lib/format";
 import { cn } from "../lib/utils";
 import { useConnectionStore } from "../stores/connection";
 import { useUIStore } from "../stores/ui";
@@ -261,6 +261,7 @@ function Row({ item, open, onToggle }: { item: Item; open: boolean; onToggle: ()
 }
 
 function CronDetail({ schedule }: { schedule: Schedule }) {
+  const zone = cronZone(schedule.timezone);
   return (
     <div className="space-y-3">
       <Field label="Prompt">
@@ -275,6 +276,7 @@ function CronDetail({ schedule }: { schedule: Schedule }) {
             </code>,
             describeCron(schedule.cronExpr),
           ],
+          ["Timezone", zone.value, zone.hint],
           ["Next run", dateTime(schedule.nextFireAt), null],
           ["Last run", dateTime(schedule.lastFiredAt), null],
           ["Created", dateTime(schedule.createdAt), null],

--- a/app/src/shared/schedule.ts
+++ b/app/src/shared/schedule.ts
@@ -8,11 +8,16 @@ import { z } from "zod";
  * live PTY if the GUI is open; else cold: a headless `claude --resume -p` run).
  */
 
-/** A 5-field cron schedule (machine-local timezone), interpreted by `croner`. */
+/**
+ * A 5-field cron schedule interpreted by `croner` in `timezone`, the machine's IANA
+ * zone when it was created (null only on pre-v6 rows not yet backfilled). The zone is
+ * host-owned and user-facing: the agent's view of a schedule omits it.
+ */
 export const Schedule = z.object({
   id: z.string(),
   agentId: z.string(),
   cronExpr: z.string(),
+  timezone: z.string().nullable(),
   prompt: z.string(),
   recurring: z.boolean(),
   enabled: z.boolean(),


### PR DESCRIPTION
## Problem

A 5-field cron expression is a wall-clock rule, not an instant. The scheduler resolved it in whatever local timezone the host process started with, so a system timezone change followed by a host restart re-armed every schedule in the new zone. The same expressions then fired hours away from the times they were written for, and the boot catch-up (which compares the previously stored next-fire against now) could skip a day's fires outright.

## Change

- **Schema v6:** `schedules.timezone` (IANA name, nullable), added via the additive `user_version` migration path.
- **Host stamps the zone at creation** and passes it to croner's `timezone` option, so a timer keeps meaning the same wall-clock time regardless of later zone changes, with DST handled in the pinned zone.
- **Zone read from the OS, not the process:** new `systemTimeZone()` checks `TZ`, then the `/etc/localtime` symlink, and falls back to the process's Intl zone. The process zone is resolved once at startup and goes stale after a system change.
- **Agent contract unchanged:** `CronCreate` still takes a cron in the machine's local time with no timezone input. The `/schedules` routes omit `timezone` from every agent-facing response, so `CronList` does not surface it either.
- **Migration behaviour:** existing rows read NULL; the scheduler backfills them with the machine's current zone on its next boot, pinning exactly the behaviour they had until then.
- **UI:** the Scheduled view and Monitor tab detail panels show the pinned zone, with a hint when it differs from the machine's current zone.
- The scheduler boot log line records the machine zone.

## Tests

- `cron-timer.test.ts`: the expression resolves in the given zone, not the process zone.
- `system-timezone.test.ts`: always returns a resolvable zone; `TZ` env precedence; invalid `TZ` ignored.
- `scheduler.test.ts`: creation stamps the zone; a stored zone is honoured on boot after the machine moves; NULL rows are backfilled and armed in the stamp.
- `migrate.test.ts`: v6 adds the column to a v5 DB, preserving rows as NULL.
- `schedules-route.test.ts`: `timezone` never appears in agent-facing create/list responses.

Full suite: 393 pass. Typecheck, production build, and biome clean on changed files.
